### PR TITLE
`wizard` - Load wizard in shadow DOM

### DIFF
--- a/packages/wizard/public/attractions/first-attraction.html
+++ b/packages/wizard/public/attractions/first-attraction.html
@@ -8,7 +8,6 @@
   <title>Attributes Wizard</title>
 
   <link rel='icon' type='image/png' href='/favicon.png'>
-  <link rel='stylesheet' href='/build/bundle.css'>
   <script async src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-cmsfilter@1/cmsfilter.js"></script>
   <script async src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-cmsload@1/cmsload.js"></script>
   <script async src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-cmsnest@1/cmsnest.js"></script>

--- a/packages/wizard/public/categories/my-category.html
+++ b/packages/wizard/public/categories/my-category.html
@@ -7,7 +7,6 @@
   <title>Attributes Wizard</title>
 
   <link rel='icon' type='image/png' href='/favicon.png'>
-  <link rel='stylesheet' href='/build/bundle.css'>
   <script async src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-cmsfilter@1/cmsfilter.js"></script>
   <script async src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-cmsload@1/cmsload.js"></script>
   <script async src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-cmsnest@1/cmsnest.js"></script>

--- a/packages/wizard/public/components/index.html
+++ b/packages/wizard/public/components/index.html
@@ -7,7 +7,6 @@
   <title>Components</title>
 
   <link rel='icon' type='image/png' href='/favicon.png'>
-  <link rel='stylesheet' href='/build/bundle.css'>
   <script async src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-cmsfilter@1/cmsfilter.js"></script>
   <script async src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-cmsload@1/cmsload.js"></script>
   <script async src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-cmsnest@1/cmsnest.js"></script>

--- a/packages/wizard/public/index.html
+++ b/packages/wizard/public/index.html
@@ -7,7 +7,6 @@
   <title>Attributes Wizard</title>
 
   <link rel='icon' type='image/png' href='/favicon.png'>
-  <link rel='stylesheet' href='/build/bundle.css'>
   <script async src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-cmsfilter@1/cmsfilter.js"></script>
   <script async src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-cmsload@1/cmsload.js"></script>
   <script async src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-cmsnest@1/cmsnest.js"></script>

--- a/packages/wizard/public/scenarios/cms-combine/scenario-1.html
+++ b/packages/wizard/public/scenarios/cms-combine/scenario-1.html
@@ -5,7 +5,6 @@
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <title>CMS Combine - Scenario 1</title>
   <link rel='icon' type='image/png' href='/favicon.png'>
-  <link rel='stylesheet' href='/build/bundle.css'>
   <script defer src='/build/bundle.js'></script>
   <!-- [Attributes by Finsweet] CMS Combine -->
   <script async src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-cmscombine@1/cmscombine.js"></script>

--- a/packages/wizard/public/scenarios/cms-filter/scenario-1.html
+++ b/packages/wizard/public/scenarios/cms-filter/scenario-1.html
@@ -5,7 +5,6 @@
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <title>CMS Filter - Scenario 1</title>
   <link rel='icon' type='image/png' href='/favicon.png'>
-  <link rel='stylesheet' href='/build/bundle.css'>
   <script defer src='/build/bundle.js'></script>
   <!-- [Attributes by Finsweet] CMS Filter -->
   <script async src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-cmsfilter@1/cmsfilter.js"></script>

--- a/packages/wizard/public/scenarios/cms-filter/scenario-2.html
+++ b/packages/wizard/public/scenarios/cms-filter/scenario-2.html
@@ -5,7 +5,6 @@
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <title>CMS Filter - Scenario 1</title>
   <link rel='icon' type='image/png' href='/favicon.png'>
-  <link rel='stylesheet' href='/build/bundle.css'>
   <script defer src='/build/bundle.js'></script>
   <!-- [Attributes by Finsweet] CMS Filter -->
   <script async src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-cmsfilter@1/cmsfilter.js"></script>

--- a/packages/wizard/public/scenarios/cms-load/scenario-1.html
+++ b/packages/wizard/public/scenarios/cms-load/scenario-1.html
@@ -5,7 +5,6 @@
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <title>Svelte app</title>
   <link rel='icon' type='image/png' href='/favicon.png'>
-  <link rel='stylesheet' href='/build/bundle.css'>
   <script defer src='/build/bundle.js'></script>
   <script async src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-cmsload@1/cmsload.js"></script>
 </head>

--- a/packages/wizard/public/scenarios/cms-nest/collection-page.html
+++ b/packages/wizard/public/scenarios/cms-nest/collection-page.html
@@ -5,7 +5,6 @@
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <title>CMS Nest - Scenario 1</title>
   <link rel='icon' type='image/png' href='/favicon.png'>
-  <link rel='stylesheet' href='/build/bundle.css'>
   <script defer src='/build/bundle.js'></script>
   <!-- [Attributes by Finsweet] CMS Nest -->
   <script async src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-cmsnest@1/cmsnest.js"></script>

--- a/packages/wizard/public/scenarios/cms-nest/scenario-1.html
+++ b/packages/wizard/public/scenarios/cms-nest/scenario-1.html
@@ -5,7 +5,6 @@
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <title>CMS Nest - Scenario 1</title>
   <link rel='icon' type='image/png' href='/favicon.png'>
-  <link rel='stylesheet' href='/build/bundle.css'>
   <script defer src='/build/bundle.js'></script>
   <!-- [Attributes by Finsweet] CMS Nest -->
   <script async src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-cmsnest@1/cmsnest.js"></script>

--- a/packages/wizard/public/scenarios/cms-previous-next/collection-item.html
+++ b/packages/wizard/public/scenarios/cms-previous-next/collection-item.html
@@ -5,7 +5,6 @@
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <title>Svelte app</title>
   <link rel='icon' type='image/png' href='/favicon.png'>
-  <link rel='stylesheet' href='/build/bundle.css'>
   <script defer src='/build/bundle.js'></script>
   <!-- [Attributes by Finsweet] CMS PrevNext -->
   <script async src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-cmsprevnext@1/cmsprevnext.js"></script>

--- a/packages/wizard/public/scenarios/cms-previous-next/scenario-1.html
+++ b/packages/wizard/public/scenarios/cms-previous-next/scenario-1.html
@@ -5,7 +5,6 @@
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <title>Svelte app</title>
   <link rel='icon' type='image/png' href='/favicon.png'>
-  <link rel='stylesheet' href='/build/bundle.css'>
   <script defer src='/build/bundle.js'></script>
   <!-- [Attributes by Finsweet] CMS PrevNext -->
   <script async src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-cmsprevnext@1/cmsprevnext.js"></script>

--- a/packages/wizard/public/scenarios/cms-select/scenario-1.html
+++ b/packages/wizard/public/scenarios/cms-select/scenario-1.html
@@ -5,7 +5,6 @@
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <title>Svelte app</title>
   <link rel='icon' type='image/png' href='/favicon.png'>
-  <link rel='stylesheet' href='/build/bundle.css'>
   <script defer src='/build/bundle.js'></script>
   <!-- [Attributes by Finsweet] CMS Select -->
   <script async src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-cmsselect@1/cmsselect.js"></script>

--- a/packages/wizard/public/scenarios/cms-slider/scenario-1.html
+++ b/packages/wizard/public/scenarios/cms-slider/scenario-1.html
@@ -5,7 +5,6 @@
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <title>Svelte app</title>
   <link rel='icon' type='image/png' href='/favicon.png'>
-  <link rel='stylesheet' href='/build/bundle.css'>
   <script defer src='/build/bundle.js'></script>
   <!-- [Attributes by Finsweet] CMS Slider -->
   <script async src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-cmsslider@1/cmsslider.js"></script>

--- a/packages/wizard/public/scenarios/cms-sort/scenario-1.html
+++ b/packages/wizard/public/scenarios/cms-sort/scenario-1.html
@@ -6,7 +6,6 @@
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <title>Svelte app</title>
   <link rel='icon' type='image/png' href='/favicon.png'>
-  <link rel='stylesheet' href='/build/bundle.css'>
   <script defer src='/build/bundle.js'></script>
   <!-- [Attributes by Finsweet] CMS Sort -->
   <script async src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-cmssort@1/cmssort.js"></script>

--- a/packages/wizard/public/scenarios/cms-tabs/scenario-1.html
+++ b/packages/wizard/public/scenarios/cms-tabs/scenario-1.html
@@ -6,7 +6,6 @@
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <title>Svelte app</title>
   <link rel='icon' type='image/png' href='/favicon.png'>
-  <link rel='stylesheet' href='/build/bundle.css'>
   <script defer src='/build/bundle.js'></script>
   <!-- [Attributes by Finsweet] CMS Tabs -->
   <script async src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-cmstabs@1/cmstabs.js"></script>

--- a/packages/wizard/public/scenarios/code-highlight/scenario-1.html
+++ b/packages/wizard/public/scenarios/code-highlight/scenario-1.html
@@ -6,7 +6,6 @@
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <title>Svelte app</title>
   <link rel='icon' type='image/png' href='/favicon.png'>
-  <link rel='stylesheet' href='/build/bundle.css'>
   <script defer src='/build/bundle.js'></script>
   <!-- [Attributes by Finsweet] Code Highlight -->
   <script async src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-codehighlight@1/codehighlight.js"></script>

--- a/packages/wizard/public/scenarios/copy-clip/scenario-1.html
+++ b/packages/wizard/public/scenarios/copy-clip/scenario-1.html
@@ -6,7 +6,6 @@
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <title>Svelte app</title>
   <link rel='icon' type='image/png' href='/favicon.png'>
-  <link rel='stylesheet' href='/build/bundle.css'>
   <script defer src='/build/bundle.js'></script>
   <!-- [Attributes by Finsweet] Copy to clipboard -->
   <script defer src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-copyclip@1/copyclip.js"></script>

--- a/packages/wizard/public/scenarios/count-items/scenario-1.html
+++ b/packages/wizard/public/scenarios/count-items/scenario-1.html
@@ -6,7 +6,6 @@
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <title>Svelte app</title>
   <link rel='icon' type='image/png' href='/favicon.png'>
-  <link rel='stylesheet' href='/build/bundle.css'>
   <script defer src='/build/bundle.js'></script>
 
   <!-- [Attributes by Finsweet] List item counter -->

--- a/packages/wizard/public/scenarios/custom-favicon/scenario-1.html
+++ b/packages/wizard/public/scenarios/custom-favicon/scenario-1.html
@@ -6,7 +6,6 @@
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <title>Svelte app</title>
   <link rel='icon' type='image/png' href='/favicon.png'>
-  <link rel='stylesheet' href='/build/bundle.css'>
   <script defer src='/build/bundle.js'></script>
   <!-- [Attributes by Finsweet] Custom favicon by page -->
   <script defer src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-favcustom@1/favcustom.js"></script>

--- a/packages/wizard/public/scenarios/custom-select/scenario-1.html
+++ b/packages/wizard/public/scenarios/custom-select/scenario-1.html
@@ -6,7 +6,6 @@
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <title>Svelte app</title>
   <link rel='icon' type='image/png' href='/favicon.png'>
-  <link rel='stylesheet' href='/build/bundle.css'>
   <script defer src='/build/bundle.js'></script>
   <!-- [Attributes by Finsweet] Custom Form Select -->
   <script defer src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-selectcustom@1/selectcustom.js"></script>

--- a/packages/wizard/public/scenarios/custom-slider-dots/scenario-1.html
+++ b/packages/wizard/public/scenarios/custom-slider-dots/scenario-1.html
@@ -6,7 +6,6 @@
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <title>Svelte app</title>
   <link rel='icon' type='image/png' href='/favicon.png'>
-  <link rel='stylesheet' href='/build/bundle.css'>
   <script defer src='/build/bundle.js'></script>
   <!-- [Attributes by Finsweet] Custom slider dots -->
   <script defer src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-sliderdots@1/sliderdots.js"></script>

--- a/packages/wizard/public/scenarios/errors/collection-item-link-not-found.html
+++ b/packages/wizard/public/scenarios/errors/collection-item-link-not-found.html
@@ -8,7 +8,6 @@
   <title>Attributes Wizard</title>
 
   <link rel='icon' type='image/png' href='/favicon.png'>
-  <link rel='stylesheet' href='/build/bundle.css'>
   <script async src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-cmsfilter@1/cmsfilter.js"></script>
   <script async src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-cmsload@1/cmsload.js"></script>
   <script async src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-cmsnest@1/cmsnest.js"></script>

--- a/packages/wizard/public/scenarios/errors/collection-item-link-not-working.html
+++ b/packages/wizard/public/scenarios/errors/collection-item-link-not-working.html
@@ -8,7 +8,6 @@
   <title>Attributes Wizard</title>
 
   <link rel='icon' type='image/png' href='/favicon.png'>
-  <link rel='stylesheet' href='/build/bundle.css'>
   <script async src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-cmsfilter@1/cmsfilter.js"></script>
   <script async src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-cmsload@1/cmsload.js"></script>
   <script async src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-cmsnest@1/cmsnest.js"></script>

--- a/packages/wizard/public/scenarios/errors/collection-item-not-found.html
+++ b/packages/wizard/public/scenarios/errors/collection-item-not-found.html
@@ -8,7 +8,6 @@
   <title>Attributes Wizard</title>
 
   <link rel='icon' type='image/png' href='/favicon.png'>
-  <link rel='stylesheet' href='/build/bundle.css'>
   <script async src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-cmsfilter@1/cmsfilter.js"></script>
   <script async src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-cmsload@1/cmsload.js"></script>
   <script async src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-cmsnest@1/cmsnest.js"></script>

--- a/packages/wizard/public/scenarios/errors/element-condition-child-of.html
+++ b/packages/wizard/public/scenarios/errors/element-condition-child-of.html
@@ -5,7 +5,6 @@
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <title>Svelte app</title>
   <link rel='icon' type='image/png' href='/favicon.png'>
-  <link rel='stylesheet' href='/build/bundle.css'>
   <script defer src='/build/bundle.js'></script>
   <script async src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-cmsload@1/cmsload.js"></script>
 </head>

--- a/packages/wizard/public/scenarios/errors/element-condition-exists.html
+++ b/packages/wizard/public/scenarios/errors/element-condition-exists.html
@@ -5,7 +5,6 @@
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <title>Svelte app</title>
   <link rel='icon' type='image/png' href='/favicon.png'>
-  <link rel='stylesheet' href='/build/bundle.css'>
   <script defer src='/build/bundle.js'></script>
   <script async src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-cmsload@1/cmsload.js"></script>
 </head>

--- a/packages/wizard/public/scenarios/errors/element-condition-has-link.html
+++ b/packages/wizard/public/scenarios/errors/element-condition-has-link.html
@@ -5,7 +5,6 @@
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <title>Svelte app</title>
   <link rel='icon' type='image/png' href='/favicon.png'>
-  <link rel='stylesheet' href='/build/bundle.css'>
   <script defer src='/build/bundle.js'></script>
   <!-- [Attributes by Finsweet] CMS PrevNext -->
   <script async src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-cmsprevnext@1/cmsprevnext.js"></script>

--- a/packages/wizard/public/scenarios/errors/element-condition-has-styles.html
+++ b/packages/wizard/public/scenarios/errors/element-condition-has-styles.html
@@ -6,7 +6,6 @@
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <title>Svelte app</title>
   <link rel='icon' type='image/png' href='/favicon.png'>
-  <link rel='stylesheet' href='/build/bundle.css'>
   <script defer src='/build/bundle.js'></script>
   <!-- [Attributes by Finsweet] Range Slider -->
   <script defer src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-rangeslider@1/rangeslider.js"></script>

--- a/packages/wizard/public/scenarios/errors/element-condition-parent.html
+++ b/packages/wizard/public/scenarios/errors/element-condition-parent.html
@@ -5,7 +5,6 @@
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <title>Svelte app</title>
   <link rel='icon' type='image/png' href='/favicon.png'>
-  <link rel='stylesheet' href='/build/bundle.css'>
   <script defer src='/build/bundle.js'></script>
   <!-- [Attributes by Finsweet] Custom Form Select -->
   <script defer src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-selectcustom@1/selectcustom.js"></script>

--- a/packages/wizard/public/scenarios/errors/element-condition-setting.html
+++ b/packages/wizard/public/scenarios/errors/element-condition-setting.html
@@ -5,7 +5,6 @@
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <title>Svelte app</title>
   <link rel='icon' type='image/png' href='/favicon.png'>
-  <link rel='stylesheet' href='/build/bundle.css'>
   <script defer src='/build/bundle.js'></script>
   <script async src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-cmsload@1/cmsload.js"></script>
 </head>

--- a/packages/wizard/public/scenarios/errors/element-condition-sibling.html
+++ b/packages/wizard/public/scenarios/errors/element-condition-sibling.html
@@ -5,7 +5,6 @@
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <title>Svelte app</title>
   <link rel='icon' type='image/png' href='/favicon.png'>
-  <link rel='stylesheet' href='/build/bundle.css'>
   <script defer src='/build/bundle.js'></script>
   <script defer src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-copyclip@1/copyclip.js"></script>
 </head>

--- a/packages/wizard/public/scenarios/errors/element-dom-not-found.html
+++ b/packages/wizard/public/scenarios/errors/element-dom-not-found.html
@@ -5,7 +5,6 @@
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <title>Svelte app</title>
   <link rel='icon' type='image/png' href='/favicon.png'>
-  <link rel='stylesheet' href='/build/bundle.css'>
   <script defer src='/build/bundle.js'></script>
   <script async src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-cmsload@1/cmsload.js"></script>
 </head>

--- a/packages/wizard/public/scenarios/errors/element-duplicated.html
+++ b/packages/wizard/public/scenarios/errors/element-duplicated.html
@@ -5,7 +5,6 @@
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <title>Svelte app</title>
   <link rel='icon' type='image/png' href='/favicon.png'>
-  <link rel='stylesheet' href='/build/bundle.css'>
   <script defer src='/build/bundle.js'></script>
   <script async src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-cmsload@1/cmsload.js"></script>
 </head>

--- a/packages/wizard/public/scenarios/errors/element-not-applied-to.html
+++ b/packages/wizard/public/scenarios/errors/element-not-applied-to.html
@@ -5,7 +5,6 @@
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <title>Svelte app</title>
   <link rel='icon' type='image/png' href='/favicon.png'>
-  <link rel='stylesheet' href='/build/bundle.css'>
   <script defer src='/build/bundle.js'></script>
   <script async src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-cmsload@1/cmsload.js"></script>
 </head>

--- a/packages/wizard/public/scenarios/errors/element-not-found.html
+++ b/packages/wizard/public/scenarios/errors/element-not-found.html
@@ -5,7 +5,6 @@
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <title>Svelte app</title>
   <link rel='icon' type='image/png' href='/favicon.png'>
-  <link rel='stylesheet' href='/build/bundle.css'>
   <script defer src='/build/bundle.js'></script>
   <script async src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-cmsload@1/cmsload.js"></script>
 </head>

--- a/packages/wizard/public/scenarios/errors/element-setting-applied-to-element.html
+++ b/packages/wizard/public/scenarios/errors/element-setting-applied-to-element.html
@@ -5,7 +5,6 @@
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <title>Svelte app</title>
   <link rel='icon' type='image/png' href='/favicon.png'>
-  <link rel='stylesheet' href='/build/bundle.css'>
   <script defer src='/build/bundle.js'></script>
   <script async src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-cmsload@1/cmsload.js"></script>
 </head>

--- a/packages/wizard/public/scenarios/errors/element-setting-condition-exists.html
+++ b/packages/wizard/public/scenarios/errors/element-setting-condition-exists.html
@@ -5,7 +5,6 @@
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <title>Svelte app</title>
   <link rel='icon' type='image/png' href='/favicon.png'>
-  <link rel='stylesheet' href='/build/bundle.css'>
   <script defer src='/build/bundle.js'></script>
   <script defer src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-mirrorclick@1/mirrorclick.js"></script>
 </head>

--- a/packages/wizard/public/scenarios/errors/element-setting-condition-setting.html
+++ b/packages/wizard/public/scenarios/errors/element-setting-condition-setting.html
@@ -5,7 +5,6 @@
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <title>Svelte app</title>
   <link rel='icon' type='image/png' href='/favicon.png'>
-  <link rel='stylesheet' href='/build/bundle.css'>
   <script defer src='/build/bundle.js'></script>
   <script async src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-cmsload@1/cmsload.js"></script>
 </head>

--- a/packages/wizard/public/scenarios/errors/element-setting-not-found.html
+++ b/packages/wizard/public/scenarios/errors/element-setting-not-found.html
@@ -5,7 +5,6 @@
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <title>Svelte app</title>
   <link rel='icon' type='image/png' href='/favicon.png'>
-  <link rel='stylesheet' href='/build/bundle.css'>
   <script defer src='/build/bundle.js'></script>
   <script async src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-cmsload@1/cmsload.js"></script>
 </head>

--- a/packages/wizard/public/scenarios/errors/element-setting-values-not-match.html
+++ b/packages/wizard/public/scenarios/errors/element-setting-values-not-match.html
@@ -5,7 +5,6 @@
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <title>Svelte app</title>
   <link rel='icon' type='image/png' href='/favicon.png'>
-  <link rel='stylesheet' href='/build/bundle.css'>
   <script defer src='/build/bundle.js'></script>
   <script async src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-cmsload@1/cmsload.js"></script>
 </head>

--- a/packages/wizard/public/scenarios/errors/element-setting-values-type-not-match.html
+++ b/packages/wizard/public/scenarios/errors/element-setting-values-type-not-match.html
@@ -5,7 +5,6 @@
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <title>Svelte app</title>
   <link rel='icon' type='image/png' href='/favicon.png'>
-  <link rel='stylesheet' href='/build/bundle.css'>
   <script defer src='/build/bundle.js'></script>
   <script async src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-cmsload@1/cmsload.js"></script>
 </head>

--- a/packages/wizard/public/scenarios/errors/field-component.html
+++ b/packages/wizard/public/scenarios/errors/field-component.html
@@ -5,7 +5,6 @@
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <title>Svelte app</title>
   <link rel='icon' type='image/png' href='/favicon.png'>
-  <link rel='stylesheet' href='/build/bundle.css'>
   <script defer src='/build/bundle.js'></script>
   <script defer src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-richtext@1/richtext.js"></script>
 </head>

--- a/packages/wizard/public/scenarios/errors/field-external-component.html
+++ b/packages/wizard/public/scenarios/errors/field-external-component.html
@@ -7,7 +7,6 @@
   <title>Components</title>
 
   <link rel='icon' type='image/png' href='/favicon.png'>
-  <link rel='stylesheet' href='/build/bundle.css'>
   <script async src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-cmsfilter@1/cmsfilter.js"></script>
   <script async src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-cmsload@1/cmsload.js"></script>
   <script async src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-cmsnest@1/cmsnest.js"></script>

--- a/packages/wizard/public/scenarios/errors/field-input.html
+++ b/packages/wizard/public/scenarios/errors/field-input.html
@@ -5,7 +5,6 @@
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <title>Svelte app</title>
   <link rel='icon' type='image/png' href='/favicon.png'>
-  <link rel='stylesheet' href='/build/bundle.css'>
   <script defer src='/build/bundle.js'></script>
   <script async src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-cmsfilter@1/cmsfilter.js"></script>
 </head>

--- a/packages/wizard/public/scenarios/errors/field-link-collection-item-link-not-found.html
+++ b/packages/wizard/public/scenarios/errors/field-link-collection-item-link-not-found.html
@@ -5,7 +5,6 @@
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <title>Svelte app</title>
   <link rel='icon' type='image/png' href='/favicon.png'>
-  <link rel='stylesheet' href='/build/bundle.css'>
   <script defer src='/build/bundle.js'></script>
   <script async src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-cmsnest@1/cmsnest.js"></script>
 </head>

--- a/packages/wizard/public/scenarios/errors/field-link-collection-item-link-not-working.html
+++ b/packages/wizard/public/scenarios/errors/field-link-collection-item-link-not-working.html
@@ -5,7 +5,6 @@
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <title>Svelte app</title>
   <link rel='icon' type='image/png' href='/favicon.png'>
-  <link rel='stylesheet' href='/build/bundle.css'>
   <script defer src='/build/bundle.js'></script>
   <script async src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-cmsnest@1/cmsnest.js"></script>
 </head>

--- a/packages/wizard/public/scenarios/errors/field-link-collection-item-not-found.html
+++ b/packages/wizard/public/scenarios/errors/field-link-collection-item-not-found.html
@@ -5,7 +5,6 @@
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <title>Svelte app</title>
   <link rel='icon' type='image/png' href='/favicon.png'>
-  <link rel='stylesheet' href='/build/bundle.css'>
   <script defer src='/build/bundle.js'></script>
   <script async src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-cmsnest@1/cmsnest.js"></script>
 </head>

--- a/packages/wizard/public/scenarios/errors/field-link-collection-link-not-found.html
+++ b/packages/wizard/public/scenarios/errors/field-link-collection-link-not-found.html
@@ -5,7 +5,6 @@
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <title>Svelte app</title>
   <link rel='icon' type='image/png' href='/favicon.png'>
-  <link rel='stylesheet' href='/build/bundle.css'>
   <script defer src='/build/bundle.js'></script>
   <script async src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-cmsnest@1/cmsnest.js"></script>
 </head>

--- a/packages/wizard/public/scenarios/errors/field-link-collection-link-not-working.html
+++ b/packages/wizard/public/scenarios/errors/field-link-collection-link-not-working.html
@@ -5,7 +5,6 @@
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <title>Svelte app</title>
   <link rel='icon' type='image/png' href='/favicon.png'>
-  <link rel='stylesheet' href='/build/bundle.css'>
   <script defer src='/build/bundle.js'></script>
   <script async src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-cmsnest@1/cmsnest.js"></script>
 </head>

--- a/packages/wizard/public/scenarios/errors/field-link-collection-not-found.html
+++ b/packages/wizard/public/scenarios/errors/field-link-collection-not-found.html
@@ -5,7 +5,6 @@
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <title>Svelte app</title>
   <link rel='icon' type='image/png' href='/favicon.png'>
-  <link rel='stylesheet' href='/build/bundle.css'>
   <script defer src='/build/bundle.js'></script>
   <script async src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-cmsnest@1/cmsnest.js"></script>
 </head>

--- a/packages/wizard/public/scenarios/errors/field-link-not-found.html
+++ b/packages/wizard/public/scenarios/errors/field-link-not-found.html
@@ -5,7 +5,6 @@
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <title>Svelte app</title>
   <link rel='icon' type='image/png' href='/favicon.png'>
-  <link rel='stylesheet' href='/build/bundle.css'>
   <script defer src='/build/bundle.js'></script>
   <script async src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-cmsnest@1/cmsnest.js"></script>
 </head>

--- a/packages/wizard/public/scenarios/errors/field-not-found.html
+++ b/packages/wizard/public/scenarios/errors/field-not-found.html
@@ -5,7 +5,6 @@
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <title>Svelte app</title>
   <link rel='icon' type='image/png' href='/favicon.png'>
-  <link rel='stylesheet' href='/build/bundle.css'>
   <script defer src='/build/bundle.js'></script>
   <script async src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-cmsfilter@1/cmsfilter.js"></script>
 </head>

--- a/packages/wizard/public/scenarios/errors/field-selector.html
+++ b/packages/wizard/public/scenarios/errors/field-selector.html
@@ -5,7 +5,6 @@
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <title>Svelte app</title>
   <link rel='icon' type='image/png' href='/favicon.png'>
-  <link rel='stylesheet' href='/build/bundle.css'>
   <script defer src='/build/bundle.js'></script>
   <script async src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-cmsfilter@1/cmsfilter.js"></script>
 </head>

--- a/packages/wizard/public/scenarios/errors/field-settings-not-found.html
+++ b/packages/wizard/public/scenarios/errors/field-settings-not-found.html
@@ -7,7 +7,6 @@
 
   <title>Attributes Wizard</title>
   <link rel='icon' type='image/png' href='/favicon.png'>
-  <link rel='stylesheet' href='/build/bundle.css'>
   <script defer src='/build/bundle.js'></script>
   <script async src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-cmsfilter@1/cmsfilter.js"></script>
 

--- a/packages/wizard/public/scenarios/errors/field-settings-specialization-range.html
+++ b/packages/wizard/public/scenarios/errors/field-settings-specialization-range.html
@@ -7,7 +7,6 @@
 
   <title>Attributes Wizard</title>
   <link rel='icon' type='image/png' href='/favicon.png'>
-  <link rel='stylesheet' href='/build/bundle.css'>
   <script defer src='/build/bundle.js'></script>
   <script async src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-cmsfilter@1/cmsfilter.js"></script>
 

--- a/packages/wizard/public/scenarios/errors/field-settings-values-not-match.html
+++ b/packages/wizard/public/scenarios/errors/field-settings-values-not-match.html
@@ -7,7 +7,6 @@
 
   <title>Attributes Wizard</title>
   <link rel='icon' type='image/png' href='/favicon.png'>
-  <link rel='stylesheet' href='/build/bundle.css'>
   <script defer src='/build/bundle.js'></script>
   <script async src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-cmsfilter@1/cmsfilter.js"></script>
 

--- a/packages/wizard/public/scenarios/errors/link-collection-link-not-found.html
+++ b/packages/wizard/public/scenarios/errors/link-collection-link-not-found.html
@@ -8,7 +8,6 @@
   <title>Attributes Wizard</title>
 
   <link rel='icon' type='image/png' href='/favicon.png'>
-  <link rel='stylesheet' href='/build/bundle.css'>
   <script async src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-cmsfilter@1/cmsfilter.js"></script>
   <script async src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-cmsload@1/cmsload.js"></script>
   <script async src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-cmsnest@1/cmsnest.js"></script>

--- a/packages/wizard/public/scenarios/link-block-edit/scenario-1.html
+++ b/packages/wizard/public/scenarios/link-block-edit/scenario-1.html
@@ -6,7 +6,6 @@
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <title>Svelte app</title>
   <link rel='icon' type='image/png' href='/favicon.png'>
-  <link rel='stylesheet' href='/build/bundle.css'>
   <script defer src='/build/bundle.js'></script>
   <!-- [Attributes by Finsweet] Link blocks in editor -->
   <script defer src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-linkblockedit@1/linkblockedit.js"></script>

--- a/packages/wizard/public/scenarios/mirror-click/scenario-1.html
+++ b/packages/wizard/public/scenarios/mirror-click/scenario-1.html
@@ -6,7 +6,6 @@
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <title>Svelte app</title>
   <link rel='icon' type='image/png' href='/favicon.png'>
-  <link rel='stylesheet' href='/build/bundle.css'>
   <script defer src='/build/bundle.js'></script>
   <!-- [Attributes by Finsweet] Mirror click events -->
   <script defer src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-mirrorclick@1/mirrorclick.js"></script>

--- a/packages/wizard/public/scenarios/mirror-input/scenario-1.html
+++ b/packages/wizard/public/scenarios/mirror-input/scenario-1.html
@@ -6,7 +6,6 @@
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <title>Svelte app</title>
   <link rel='icon' type='image/png' href='/favicon.png'>
-  <link rel='stylesheet' href='/build/bundle.css'>
   <script defer src='/build/bundle.js'></script>
   <!-- [Attributes by Finsweet] Mirror input values -->
   <script defer src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-mirrorinput@1/mirrorinput.js"></script>

--- a/packages/wizard/public/scenarios/range-slider/scenario-1.html
+++ b/packages/wizard/public/scenarios/range-slider/scenario-1.html
@@ -6,7 +6,6 @@
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <title>Svelte app</title>
   <link rel='icon' type='image/png' href='/favicon.png'>
-  <link rel='stylesheet' href='/build/bundle.css'>
   <script defer src='/build/bundle.js'></script>
   <!-- [Attributes by Finsweet] Range Slider -->
   <script defer src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-rangeslider@1/rangeslider.js"></script>

--- a/packages/wizard/public/scenarios/rich-text/component.html
+++ b/packages/wizard/public/scenarios/rich-text/component.html
@@ -6,7 +6,6 @@
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <title>Svelte app</title>
   <link rel='icon' type='image/png' href='/favicon.png'>
-  <link rel='stylesheet' href='/build/bundle.css'>
   <script defer src='/build/bundle.js'></script>
 </head>
 

--- a/packages/wizard/public/scenarios/rich-text/scenario-1.html
+++ b/packages/wizard/public/scenarios/rich-text/scenario-1.html
@@ -6,7 +6,6 @@
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <title>Svelte app</title>
   <link rel='icon' type='image/png' href='/favicon.png'>
-  <link rel='stylesheet' href='/build/bundle.css'>
   <script defer src='/build/bundle.js'></script>
   <script defer src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-richtext@1/richtext.js"></script>
 </head>

--- a/packages/wizard/public/scenarios/scroll-disable/scenario-1.html
+++ b/packages/wizard/public/scenarios/scroll-disable/scenario-1.html
@@ -6,7 +6,6 @@
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <title>Svelte app</title>
   <link rel='icon' type='image/png' href='/favicon.png'>
-  <link rel='stylesheet' href='/build/bundle.css'>
   <script defer src='/build/bundle.js'></script>
   <!-- [Attributes by Finsweet] Disable scrolling -->
   <script defer src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-scrolldisable@1/scrolldisable.js"></script>

--- a/packages/wizard/public/scenarios/smart-lightbox/scenario-1.html
+++ b/packages/wizard/public/scenarios/smart-lightbox/scenario-1.html
@@ -6,7 +6,6 @@
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <title>Svelte app</title>
   <link rel='icon' type='image/png' href='/favicon.png'>
-  <link rel='stylesheet' href='/build/bundle.css'>
   <script defer src='/build/bundle.js'></script>
   <!-- [Attributes by Finsweet] Smart Lightbox -->
   <script defer src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-smartlightbox@1/smartlightbox.js"></script>

--- a/packages/wizard/public/scenarios/template.html
+++ b/packages/wizard/public/scenarios/template.html
@@ -6,7 +6,6 @@
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <title>Svelte app</title>
   <link rel='icon' type='image/png' href='/favicon.png'>
-  <link rel='stylesheet' href='/build/bundle.css'>
   <script defer src='/build/bundle.js'></script>
   <!-- [Attributes by Finsweet] Copy to clipboard -->
   <script defer src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-copyclip@1/copyclip.js"></script>

--- a/packages/wizard/rollup.config.js
+++ b/packages/wizard/rollup.config.js
@@ -5,7 +5,7 @@ import livereload from 'rollup-plugin-livereload';
 import { terser } from 'rollup-plugin-terser';
 import sveltePreprocess from 'svelte-preprocess';
 import typescript from '@rollup/plugin-typescript';
-import css from 'rollup-plugin-css-only';
+// import css from 'rollup-plugin-css-only';
 import alias from '@rollup/plugin-alias';
 import path from 'path'
 import { svelteSVG } from "rollup-plugin-svelte-svg";
@@ -60,11 +60,12 @@ export default {
       compilerOptions: {
         // enable run-time checks when not in production
         dev: !production
-      }
+      },
+      emitCss: false,
     }),
     // we'll extract any component CSS out into
     // a separate file - better for performance
-    css({ output: 'bundle.css' }),
+    // css({ output: 'bundle.css' }),
 
     // If you have external dependencies installed from
     // npm, you'll most likely need these plugins. In

--- a/packages/wizard/src/directives/clickOutside.ts
+++ b/packages/wizard/src/directives/clickOutside.ts
@@ -2,7 +2,11 @@
 export function clickOutside(node: Node) {
 
   const handleClick = (event: MouseEvent) => {
-    if (node && !node.contains(event.target as Node | null) && !event.defaultPrevented) {
+
+    const composedPath = event.composedPath();
+    const target = composedPath[0];
+
+    if (node && !node.contains(target as Node | null) && !event.defaultPrevented) {
 
       event.stopPropagation();
       node.dispatchEvent(

--- a/packages/wizard/src/main.ts
+++ b/packages/wizard/src/main.ts
@@ -1,8 +1,51 @@
 import App from './App.svelte';
 
+const section = document.createElement('section');
+section.setAttribute('data-id', 'wizard-wrapper');
+
+document.body.appendChild(section);
+
+const root = section.attachShadow({ mode: 'open' });
+
 const app = new App({
-  target: document.body,
+  target: root,
   props: {},
 });
+
+
+const styleFonts = `
+  @font-face {
+    font-family: 'Open Sans';
+    font-style: normal;
+    font-weight: 300;
+    src: local('Open Sans Light'),
+      local('OpenSans-Light'),
+      url(https://fonts.gstatic.com/s/opensans/v13/DXI1ORHCpsQm3Vp6mXoaTXhCUOGz7vYGh680lGh-uXM.woff)
+      format('woff');
+  }
+
+  @font-face {
+    font-family: 'Open Sans';
+    font-style: normal;
+    font-weight: 400;
+    src: local('Open Sans'),
+    local('OpenSans'),
+    url(https://fonts.gstatic.com/s/opensans/v13/cJZKeOuBrn4kERxqtaUH3T8E0i7KZn-EPnyo3HZu7kw.woff) format('woff');
+  }
+
+  @font-face {
+    font-family: 'Open Sans';
+    font-style: normal;
+    font-weight: 600;
+    src: local('Open Sans Semibold'),
+    local('OpenSans-Semibold'),
+    url(https://fonts.gstatic.com/s/opensans/v13/MTP_ySUJH_bn48VBG8sNSnhCUOGz7vYGh680lGh-uXM.woff)
+    format('woff');
+  }
+`
+const style = document.createElement('style');
+style.setAttribute('type', 'text/css');
+style.appendChild(document.createTextNode(styleFonts));
+document.head.appendChild(style);
 
 export default app;

--- a/packages/wizard/tests/helpers/pageObject.js
+++ b/packages/wizard/tests/helpers/pageObject.js
@@ -1,62 +1,63 @@
 import { Selector } from 'testcafe';
 
 
+
+const wizardWrapper = Selector('[data-id="wizard-wrapper"]').shadowRoot();
+
+
 /**
  * Walkthrought
  */
-export const walkthrought = Selector('[data-testid="walkthrough"]');
+export const walkthrought = wizardWrapper.find('[data-testid="walkthrough"]');
 
 /**
  * Header
  */
-export const headerSection = Selector('[data-testid="walkthrough-header"]');
+export const headerSection = wizardWrapper.find('[data-testid="walkthrough-header"]');
 export const headerButton = headerSection.find('[data-testid="action"]');
 
-export const attributeHeader = Selector('[data-testid="attribute-header"]')
+export const attributeHeader = wizardWrapper.find('[data-testid="attribute-header"]')
 
 /**
  * Attributes
  */
 //export const attributesSection = Selector('[data-testid="walkthrough-attributes"]');
-export const attributesSelect = Selector('[data-testid="select-attribute"]');
-export const attributesDisplay = Selector('[data-testid="select-attribute-display"]');
-export const attributesOptions = Selector('[data-testid="select-attribute-option"]');
+// export const attributesSelect = Selector('[data-testid="select-attribute"]');
+export const attributesDisplay = wizardWrapper.find('[data-testid="select-attribute-display"]');
+
+export const attributesOptions = wizardWrapper.find('[data-testid="select-attribute-option"]');
 
 /**
  * Instances
  */
-export const toggleInstances = Selector('[data-testid="select-attribute-toggle-instances"]');
-export const inputInstances = Selector('[data-testid="select-attribute-input-instances"]');
-export const moreInstances = Selector('[data-testid="select-attribute-more-instances"]');
-export const minusInstances = Selector('[data-testid="select-attribute-minus-instances"]');
+export const toggleInstances = wizardWrapper.find('[data-testid="select-attribute-toggle-instances"]');
+export const inputInstances = wizardWrapper.find('[data-testid="select-attribute-input-instances"]');
+export const moreInstances = wizardWrapper.find('[data-testid="select-attribute-more-instances"]');
+export const minusInstances = wizardWrapper.find('[data-testid="select-attribute-minus-instances"]');
 
-export const instanceButtons = Selector('[data-testid="select-attribute-instance"]');
+export const instanceButtons = wizardWrapper.find('[data-testid="select-attribute-instance"]');
 
 
 // export const instancesSection = Selector('[data-testid="walkthrough-instances"]');
-export const instancesMoreButton = Selector('#more-instances');
-export const instancesInput = Selector('#instances');
+export const instancesMoreButton = wizardWrapper.find('#more-instances');
+export const instancesInput = wizardWrapper.find('#instances');
 
 
 /**
  * Select instance
  */
-export const selectInstanceSection = Selector('[data-testid="walkthrough-select-instance"]');
+export const selectInstanceSection = wizardWrapper.find('[data-testid="walkthrough-select-instance"]');
 
 /**
  * Schema
  */
 
-// export const schemaSection = Selector('[data-testid="walkthrough-schema"]');
-// export const schemaElementsSection = Selector('[data-testid="walkthrough-schema-elements"]');
-// export const schemaSettingsSection = Selector('[data-testid="walkthrough-schema-settings"]');
 export const getItemCheckbox = (attributeId) => {
-
-  return Selector(`#${attributeId} label input[type=checkbox]`);
+  return wizardWrapper.find(`#${attributeId} label input[type=checkbox]`);
 }
 
 export const getItemToggle = (attributeId) => {
-  return Selector(`#${attributeId} [data-testid="attribute-toggle"]`);
+  return wizardWrapper.find(`#${attributeId} [data-testid="attribute-toggle"]`);
 }
 /**
  * Script
@@ -69,7 +70,7 @@ export const scriptSection = Selector('[data-testid="walkthrough-script"]');
 export const actionSection = Selector('[data-testid="walkthrough-action"]');
 export const actionButton = actionSection.find('[data-testid="action"]');
 
-export const runCheckBtn = Selector('[data-testid="run-check"]');
+export const runCheckBtn = wizardWrapper.find('[data-testid="run-check"]');
 export const resetBtn = Selector('[data-testid="reset"]');
 
 /**
@@ -78,11 +79,11 @@ export const resetBtn = Selector('[data-testid="reset"]');
 // export const reportSection = Selector('[data-testid="walkthrough-report"]');
 // export const reportResponse = reportSection.find('[data-testid="report-list"]');
 
-export const reportItems = Selector('[data-testid="report-item"]')
+export const reportItems = wizardWrapper.find('[data-testid="report-item"]')
 
 
 export const getAddFieldButton = (index = 1) => {
-  const elements = Selector(`[data-testid="add-field"]`);
+  const elements = wizardWrapper.find(`[data-testid="add-field"]`);
 
   return (elements.count > 1) ? elements[index - 1] : elements;
 }
@@ -90,41 +91,41 @@ export const getAddFieldButton = (index = 1) => {
 
 export const getReportError = (attributeId, index = 1) => {
 
-  return Selector(`[data-test="${attributeId}"]`);
+  return wizardWrapper.find(`[data-test="${attributeId}"]`);
 }
 
 export const getAttributeError = (attributeId, index = 1) => {
 
-  const elements = Selector(`#${attributeId} [data-testid="attribute-error"]`);
+  const elements = wizardWrapper.find(`#${attributeId} [data-testid="attribute-error"]`);
 
   return (elements.count > 1) ? elements[index - 1] : elements;
   //return Selector(`#${attributeId} [data-testid="attribute-error"]`);
 }
 
 export const getItemSelect = (attributeId) => {
-  const elements = Selector(`#${attributeId} [data-testid="settings-select"]`);
+  const elements = wizardWrapper.find(`#${attributeId} [data-testid="settings-select"]`);
   return (elements.count > 1) ? elements[index -1] : elements;
 }
 
 export const getItemSelectOptions = (attributeId) => {
-  return Selector(`#${attributeId} [data-testid="settings-select-option"]`);
+  return wizardWrapper.find(`#${attributeId} [data-testid="settings-select-option"]`);
 }
 
 export const getItemInput = (attributeId) => {
-  const elements = Selector(`#${attributeId} [data-testid="selector-input"]`);
+  const elements = wizardWrapper.find(`#${attributeId} [data-testid="selector-input"]`);
   return (elements.count > 1) ? elements[index -1] : elements;
 }
 
 export const getFieldIdentifier = (attributeId) => {
-  return Selector(`#${attributeId} [data-testid="field-identifier"]`);
+  return wizardWrapper.find(`#${attributeId} [data-testid="field-identifier"]`);
 }
 
 
 export const getFieldSpecialization = (attributeId) => {
 
-  return Selector(`#${attributeId} [data-testid="field-specialization"]`);
+  return wizardWrapper.find(`#${attributeId} [data-testid="field-specialization"]`);
 }
 
 export const getFieldSpecializationOptions = (attributeId) => {
-  return Selector(`#${attributeId} [data-testid="field-specialization-option"]`);
+  return wizardWrapper.find(`#${attributeId} [data-testid="field-specialization-option"]`);
 }


### PR DESCRIPTION
Changes:

- Added logic for load Svelte App in a Shadow Root.
- Added logic to import fonts in Light DOM.
- Changed CSS generated code, from external file to the HEAD of Component.
- Updated  click_outside directive to handle clicks inside shadow DOM properly.
- Updated tests selector