### PR TITLE
Created `importSupport()` global method

### DIFF
--- a/global/factory/init.ts
+++ b/global/factory/init.ts
@@ -1,4 +1,5 @@
 import { ATTRIBUTES, getSelector } from '$global/constants/attributes';
+import { importSupport } from '$global/import/support';
 import type { FsAttributes, FsAttributesCallback } from '$global/types/global';
 
 /**
@@ -19,6 +20,8 @@ export const initAttributes = () => {
 
   window.fsAttributes = fsAttributes;
   window.FsAttributes = window.fsAttributes;
+
+  importSupport();
 };
 
 /**

--- a/global/import/support.ts
+++ b/global/import/support.ts
@@ -1,0 +1,35 @@
+import { ATTRIBUTES_PREFIX } from '$global/constants/attributes';
+
+const ATTRIBUTES_SUPPORT_QUERY_PARAM = `${ATTRIBUTES_PREFIX}-support`;
+const ATTRIBUTES_SUPPORT_SOURCE = 'https://cdn.jsdelivr.net/npm/@finsweet/attributes-support@1/public/build/bundle.js';
+
+/**
+ * Imports the Attributes Support Wizard and mounts it on the page.
+ * It stores the import as a Promise to ensure it isn't mounted more than once.
+ *
+ * @returns A promise that resolves to `true` if the app was successfuly loaded.
+ */
+export const importSupport = async () => {
+  const { fsAttributes, location } = window;
+  const { host, searchParams } = new URL(location.href);
+
+  if (!host.includes('webflow.io') || !searchParams.has(ATTRIBUTES_SUPPORT_QUERY_PARAM)) return false;
+
+  if (fsAttributes.supportImport) return fsAttributes.supportImport;
+
+  try {
+    fsAttributes.supportImport = new Promise((resolve, reject) => {
+      const script = document.createElement('script');
+
+      script.src = ATTRIBUTES_SUPPORT_SOURCE;
+      script.onload = () => resolve(true);
+      script.onerror = reject;
+
+      document.head.append(script);
+    });
+  } catch (error) {
+    return false;
+  }
+
+  return fsAttributes.supportImport;
+};

--- a/global/types/global.ts
+++ b/global/types/global.ts
@@ -14,6 +14,7 @@ export type FsAttributesCallback =
 
 type FsAttributesBase = {
   animationImport?: AnimationImport;
+  supportImport?: Promise<boolean>;
 
   push: (...args: FsAttributesCallback[]) => void;
 
@@ -26,7 +27,8 @@ type FsAttributesBase = {
   };
 };
 
-export interface FsAttributeInit<T = unknown> {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export interface FsAttributeInit<T = any> {
   version?: string;
   init?: () => T | Promise<T>;
   loading?: Promise<T>;


### PR DESCRIPTION
Created `importSupport()` global method and included it in the `initAttributes()` factory.

To include this new feature in all Attributes, we need to re-bundle and publish all of them to NPM so they include this update in the factory init.

@mauriciopiber This is the perfect timing to also publish the schemas to all attributes, so we kill two birds with one shot .