### PR TITLE
Delete .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,0 @@
-CUSTOM_BUILD_DIRECTORY=C:/Example Folder/Example Subfolder


### PR DESCRIPTION
We previously used `dotenv` to set a custom output directory for dev purposes, but we no longer use it.