### PR TITLE
`cmssort`: Added support for decimal and negative numbers

### DIFF
--- a/.changeset/late-pants-shop.md
+++ b/.changeset/late-pants-shop.md
@@ -1,0 +1,5 @@
+---
+"@finsweet/attributes-cmssort": minor
+---
+
+Added support for decimal and negative numbers using `fs-cmssort-type="number"`

--- a/packages/cmscore/src/utils/types.ts
+++ b/packages/cmscore/src/utils/types.ts
@@ -58,7 +58,7 @@ export interface CMSItemProps {
 
     /**
      * Defines the type of the value.
-     * @example `date`
+     * @example `date` | `number`
      */
     type?: string | null;
 

--- a/packages/cmssort/src/actions/sort.ts
+++ b/packages/cmssort/src/actions/sort.ts
@@ -42,15 +42,24 @@ export const sortListItems = async (
 
       const { type } = firstItemProp;
 
-      if (type === 'date') {
-        const firstItemTime = new Date(firstItemValue).getTime();
-        const secondItemTime = new Date(secondItemValue).getTime();
+      // Date & Number sorting
+      const isDate = type === 'date';
+      const isNumber = type === 'number';
 
-        if (direction === 'asc') return firstItemTime - secondItemTime;
+      if (isDate || isNumber) {
+        const [firstItemNumber, secondItemNumber] = [firstItemValue, secondItemValue].map((value) =>
+          isDate ? new Date(value).getTime() : parseFloat(value)
+        );
 
-        return secondItemTime - firstItemTime;
+        if (isNaN(firstItemNumber)) return 1;
+        if (isNaN(secondItemNumber)) return -1;
+
+        if (direction === 'asc') return firstItemNumber - secondItemNumber;
+
+        return secondItemNumber - firstItemNumber;
       }
 
+      // String sorting
       const collatorOptions: Intl.CollatorOptions = {
         numeric: true,
         sensitivity: 'base',


### PR DESCRIPTION
Added new `fs-cmssort-type="number"` attribute that can be added to any field in the Colleciton Items.
This Attribute defines a field as a `number` type so the library can better handle decimal and negative values.