### PR TITLE
`cmsnest`: Prevented duplicated sources inside the Template Page

### DIFF
--- a/.changeset/yellow-balloons-lay.md
+++ b/.changeset/yellow-balloons-lay.md
@@ -1,0 +1,7 @@
+---
+"@finsweet/attributes-cmsnest": patch
+---
+
+`Fix`: prevented `cmsnest` from crashing when the user has incorreclty set up a duplicated Collection List source inside the item's Template Page.
+Previously, the library tried to nest the same Collection under a single target for each source that was located in the Template Page.
+Now the library will detect this invalid setup and just populate a single instance of each Collection for each nest target.

--- a/packages/cmsnest/src/actions/populate.ts
+++ b/packages/cmsnest/src/actions/populate.ts
@@ -33,12 +33,17 @@ export const populateNestedCollections = async (
   const pageCollectionListWrappers = getCollectionListWrappers([getSelector('collection')], page);
 
   // Populate the nested CMS lists only with the correspondent nested items
+  // Also, make sure that the Collections in the Template Page are not duplicated
+  const processedPageCollections: Set<string> = new Set();
+
   await Promise.all(
     pageCollectionListWrappers.map(async (pageCollectionListWrapper, index) => {
       const pageListInstance = new CMSList(pageCollectionListWrapper, index);
 
       const collectionId = normalizePropKey(pageListInstance.getAttribute(ATTRIBUTES.collection.key));
-      if (!collectionId) return;
+      if (!collectionId || processedPageCollections.has(collectionId)) return;
+
+      processedPageCollections.add(collectionId);
 
       const nestSource = nestSources.get(collectionId);
       const nestTarget = nestTargets.get(collectionId);


### PR DESCRIPTION
`Fix`: prevented `cmsnest` from crashing when the user has incorreclty set up a duplicated Collection List source inside the item's Template Page.
Previously, the library tried to nest the same Collection under a single target for each source that was located in the Template Page.
Now the library will detect this invalid setup and just populate a single instance of each Collection for each nest target.