### PR TITLE
`cmsfilter`: Added new `fs-cmsfilter-allowsubmit="true"` option

### DIFF
--- a/.changeset/strange-moons-know.md
+++ b/.changeset/strange-moons-know.md
@@ -1,0 +1,7 @@
+---
+"@finsweet/attributes-cmsfilter": minor
+---
+
+Added new `fs-cmsfilter-allowsubmit="true"` option to allow the users to submit the filters form.
+
+By default, form submissions are disabled in Attributes CMS Filter. Set `fs-cmsfilter-allowsubmit="true"` option to the CMS List to enable form submissions in your Filter UI.

--- a/packages/cmsfilter/api/schema.ts
+++ b/packages/cmsfilter/api/schema.ts
@@ -38,6 +38,7 @@ import {
   RANGE_SETTING_KEY,
   TYPE_SETTING_KEY,
   SHOW_QUERY_SETTING_KEY,
+  ALLOW_SUBMIT_SETTING_KEY,
   HIGHLIGHT_SETTING_KEY,
   HIGHLIGHT_CLASS_SETTING_KEY,
   ACTIVE_CLASS_SETTING_KEY,
@@ -469,7 +470,18 @@ export const schema: AttributeSchema = {
         default: 'true',
       },
     },
-
+    {
+      key: ALLOW_SUBMIT_SETTING_KEY,
+      description: 'Defines if the filters form should not prevent default behavior when submitting it.',
+      appliedTo: {
+        elements: [LIST_ELEMENT_KEY],
+      },
+      conditions: [],
+      value: {
+        type: 'boolean',
+        default: 'true',
+      },
+    },
     {
       key: TAG_FORMAT_SETTING_KEY,
       description: 'Defines the format of the tag.',

--- a/packages/cmsfilter/package.json
+++ b/packages/cmsfilter/package.json
@@ -19,7 +19,8 @@
     "check": "tsc --noEmit",
     "format": "prettier --write ./src",
     "test": "pnpm playwright test",
-    "test:headed": "pnpm playwright test --headed"
+    "test:headed": "pnpm playwright test --headed",
+    "serve": "serve ../../"
   },
   "repository": {
     "type": "git",

--- a/packages/cmsfilter/src/components/CMSFilters.ts
+++ b/packages/cmsfilter/src/components/CMSFilters.ts
@@ -97,6 +97,11 @@ export class CMSFilters {
   private readonly showQueryParams;
 
   /**
+   * Defines if the filters form should not prevent default behavior when submitting it.
+   */
+  private readonly allowSubmit;
+
+  /**
    * Defines the global active CSS class to apply on active filters.
    */
   private readonly activeCSSClass: string;
@@ -129,6 +134,7 @@ export class CMSFilters {
     {
       resultsElement,
       showQueryParams,
+      allowSubmit,
       highlightAll,
       highlightCSSClass,
       activeCSSClass,
@@ -136,6 +142,7 @@ export class CMSFilters {
     }: {
       resultsElement: HTMLElement | null;
       showQueryParams: boolean;
+      allowSubmit: boolean;
       highlightAll: boolean;
       highlightCSSClass: string;
       activeCSSClass: string;
@@ -149,6 +156,7 @@ export class CMSFilters {
     this.resetButtonsData = resetButtonsData;
     this.resultsElement = resultsElement;
     this.showQueryParams = showQueryParams;
+    this.allowSubmit = allowSubmit;
     this.activeCSSClass = activeCSSClass;
     this.debouncing = debouncing;
     this.highlightAll = highlightAll;
@@ -247,8 +255,10 @@ export class CMSFilters {
    * @param e The `Submit` event.
    */
   private async handleSubmit(e: Event) {
-    e.preventDefault();
-    e.stopImmediatePropagation();
+    if (!this.allowSubmit) {
+      e.preventDefault();
+      e.stopImmediatePropagation();
+    }
 
     await this.applyFilters();
   }

--- a/packages/cmsfilter/src/factory.ts
+++ b/packages/cmsfilter/src/factory.ts
@@ -20,6 +20,7 @@ const {
   duration: { key: durationKey },
   easing: { key: easingKey },
   showQuery: { key: showQueryKey, values: showQueryValues },
+  allowSubmit: { key: allowSubmitKey, values: allowSubmitValues },
   tagFormat: { key: tagsFormatKey },
   highlight: { key: highlightKey, values: highlightValues },
   highlightCSS: { key: highlightCSSKey },
@@ -68,6 +69,9 @@ export const createCMSFiltersInstance = (listInstance: CMSList): CMSFilters | un
   // Query Params
   const showQueryParams = listInstance.getAttribute(showQueryKey) === showQueryValues.true;
 
+  // Allow Form Submission
+  const allowSubmit = listInstance.getAttribute(allowSubmitKey) === allowSubmitValues.true;
+
   // Highlight
   const highlightAll = listInstance.getAttribute(highlightKey) === highlightValues.true;
   const highlightCSSClass = listInstance.getAttribute(highlightCSSKey) || DEFAULT_HIGHLIGHT_CSS_CLASS;
@@ -91,6 +95,7 @@ export const createCMSFiltersInstance = (listInstance: CMSList): CMSFilters | un
   const filtersInstance = new CMSFilters(formBlock, listInstance, {
     resultsElement,
     showQueryParams,
+    allowSubmit,
     highlightAll,
     highlightCSSClass,
     activeCSSClass,

--- a/packages/cmsfilter/src/utils/constants.ts
+++ b/packages/cmsfilter/src/utils/constants.ts
@@ -26,6 +26,8 @@ export const TYPE_SETTING_KEY = 'type';
 export const TYPE_SETTING_VALUES = { date: 'date' } as const;
 export const SHOW_QUERY_SETTING_KEY = 'showquery';
 export const SHOW_QUERY_SETTING_VALUES = { true: 'true' } as const;
+export const ALLOW_SUBMIT_SETTING_KEY = 'allowsubmit';
+export const ALLOW_SUBMIT_SETTING_VALUES = { true: 'true' } as const;
 export const HIDE_EMPTY_SETTING_KEY = 'hideempty';
 export const HIDE_EMPTY_SETTING_VALUES = { true: 'true' } as const;
 export const HIGHLIGHT_SETTING_KEY = 'highlight';
@@ -143,6 +145,11 @@ export const ATTRIBUTES = {
    * Defines if the filter query params should be displayed on the URL.
    */
   showQuery: { key: `${ATTRIBUTES_PREFIX}-${SHOW_QUERY_SETTING_KEY}`, values: SHOW_QUERY_SETTING_VALUES },
+
+  /**
+   * Defines if the filters form should not prevent default behavior when submitting it.
+   */
+  allowSubmit: { key: `${ATTRIBUTES_PREFIX}-${ALLOW_SUBMIT_SETTING_KEY}`, values: ALLOW_SUBMIT_SETTING_VALUES },
 
   /**
    * Defines if a filter element should be hidden when there are no results for it.

--- a/packages/cmsfilter/tests/cmsfilter.spec.ts
+++ b/packages/cmsfilter/tests/cmsfilter.spec.ts
@@ -1,5 +1,4 @@
 import { test, expect } from '@playwright/test';
-import type { Page } from '@playwright/test';
 
 /**
  * These are some demo tests to showcase Playwright.
@@ -7,12 +6,17 @@ import type { Page } from '@playwright/test';
  * If you need more info about writing tests, please visit {@link https://playwright.dev/}.
  */
 
-// test.beforeEach(async ({ page }) => {
-//   await page.goto('https://demo.playwright.dev/todomvc');
-// });
+test.beforeEach(async ({ page }) => {
+  await page.goto('https://fs-attributes.webflow.io/cms/cmsfilter');
+});
 
-test.describe('Example', () => {
-  test('Example', async ({ page }) => {
-    //
+test.describe('fs-cmsfilter-allowsubmit', () => {
+  test('Clicking submit should submit the form', async ({ page }) => {
+    await page.locator('[data-test="color-radio"]').nth(1).click({ force: true });
+    await expect(page.locator('[data-test="color-radio"]').nth(1)).toBeChecked();
+
+    await page.locator('[data-test="submit-2"]').click();
+
+    await expect(page.locator('[data-test="form-success"]')).toBeVisible();
   });
 });


### PR DESCRIPTION
Added new `fs-cmsfilter-allowsubmit="true"` option to allow the users to submit the filters form.

By default, form submissions are disabled in Attributes CMS Filter. Set `fs-cmsfilter-allowsubmit="true"` option to the CMS List to enable form submissions in your Filter UI.