### PR TITLE
`cmsload`: Fixed typo in the API docs

### DIFF
--- a/.changeset/silent-days-collect.md
+++ b/.changeset/silent-days-collect.md
@@ -1,0 +1,5 @@
+---
+"@finsweet/attributes-cmsload": patch
+---
+
+Fixed typo in the API docs


### PR DESCRIPTION
The change was already commited but I need to bump a patch version to trigger an automated deploy to NPM.