### PR TITLE
`cmsfilter`: Improved a11ty for `reset` Radio buttons

### DIFF
--- a/.changeset/stupid-poems-roll.md
+++ b/.changeset/stupid-poems-roll.md
@@ -1,0 +1,9 @@
+---
+"@finsweet/attributes-cmsfilter": patch
+---
+
+Improved accessibility for when `fs-cmsfilter-element="reset"` is applied to a Radio button.
+
+Previously, only clicks on the `fs-cmsfilter-element="reset"` elements were supported, making Radio buttons not accessible when using them with the keyboard.
+
+Now the library will detect if `fs-cmsfilter-element="reset"` is being used on a Radio button and listen for `input` events too.

--- a/packages/cmsfilter/src/components/CMSFilters.ts
+++ b/packages/cmsfilter/src/components/CMSFilters.ts
@@ -1,5 +1,5 @@
 import type { CMSList } from '@finsweet/attributes-cmscore';
-import { isFormField, isVisible, sameValues } from '@finsweet/ts-utils';
+import { FORM_CSS_CLASSES, isFormField, isVisible, sameValues } from '@finsweet/ts-utils';
 import type { FormBlockElement } from '@finsweet/ts-utils';
 import { importAnimations } from '@global/import';
 import debounce from 'just-debounce';
@@ -205,7 +205,17 @@ export class CMSFilters {
 
     // Reset buttons
     for (const [resetButton, filterKeys] of resetButtonsData) {
-      resetButton?.addEventListener('click', () => this.resetFilters(filterKeys));
+      resetButton.addEventListener('click', () => this.resetFilters(filterKeys));
+
+      const radioField = resetButton.closest(`.${FORM_CSS_CLASSES.radioField}`);
+      if (!radioField) continue;
+
+      const radio = radioField.querySelector('input');
+      if (!radio) continue;
+
+      radio.addEventListener('input', () => {
+        if (radio.checked) this.resetFilters(filterKeys);
+      });
     }
 
     // Submit button visibility


### PR DESCRIPTION
Improved accessibility for when `fs-cmsfilter-element="reset"` is applied to a Radio button.
Previously, only clicks on the `fs-cmsfilter-element="reset"` elements were supported, making Radio buttons not accessible when using them with the keyboard.
Now the library will detect if `fs-cmsfilter-element="reset"` is being used on a Radio button and listen for `input` events too.