### PR TITLE
Updated `assessScript()` to parse custom `<script>` Attributes

### DIFF
--- a/global/base/index.d.ts
+++ b/global/base/index.d.ts
@@ -29,7 +29,8 @@ type FsAttributesBase = {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 interface FsAttributeInit<T = any> {
   version?: string;
-  init?: () => T | Promise<T>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  init?: (...args: any[]) => T | Promise<T>;
   loading?: Promise<T>;
   resolve?: (value: T) => void;
 }

--- a/global/factory/assess.ts
+++ b/global/factory/assess.ts
@@ -1,23 +1,36 @@
-import { Debug } from '@finsweet/ts-utils';
-
 import { ATTRIBUTES } from './constants';
 import type { GlobalAttributeParams } from './types';
 
 /**
  * Checks the global params of the Attribute `<script>`.
- * @param script The `<script>` element.
+ * @param attributeKeys A record with Attribute keys that should be read from the <script> tag.
+ *
  * @returns The {@link GlobalAttributeParams}.
  */
-
-export const assessScript = (): GlobalAttributeParams => {
+export const assessScript = <AttributeKeys extends Record<string, string>>(
+  attributeKeys?: AttributeKeys
+): GlobalAttributeParams<AttributeKeys> => {
   const { currentScript } = document;
-  const { preventLoad, debugMode } = ATTRIBUTES;
+
+  const attributes = {} as GlobalAttributeParams<AttributeKeys>['attributes'];
+
+  if (!currentScript) {
+    return { attributes, preventsLoad: false };
+  }
 
   // Check if the Attribute should not be automatically loaded
-  const preventsLoad = typeof currentScript?.getAttribute(preventLoad.key) === 'string';
+  const preventsLoad = typeof currentScript.getAttribute(ATTRIBUTES.preventLoad.key) === 'string';
 
-  // Check if Debug Mode is activated
-  if (typeof currentScript?.getAttribute(debugMode.key) === 'string') Debug.activateAlerts();
+  // Retrieve <script> Attributes
+  const params: GlobalAttributeParams<AttributeKeys> = {
+    preventsLoad,
+    attributes,
+  };
 
-  return { preventsLoad };
+  for (const key in attributeKeys) {
+    const value = currentScript.getAttribute(attributeKeys[key]);
+    params.attributes[key] = value;
+  }
+
+  return params;
 };

--- a/global/factory/types.ts
+++ b/global/factory/types.ts
@@ -8,10 +8,15 @@ export type AttributeOperator = 'prefixed' | 'suffixed' | 'contains';
 /**
  * Global params.
  */
-export interface GlobalAttributeParams {
+export interface GlobalAttributeParams<AttributeKeys extends Record<string, string>> {
   /**
    * Defines if the `<script>` should prevent automatically loading the library.
    * Useful for cases where a JS developer whants to programatically init the library.
    */
   preventsLoad: boolean;
+
+  /**
+   * The parsed custom attributes from the <script> tag.
+   */
+  attributes: { [Key in keyof AttributeKeys]: string | null };
 }

--- a/packages/greenhouse/src/index.ts
+++ b/packages/greenhouse/src/index.ts
@@ -3,6 +3,7 @@ import { GREENHOUSE_ATTRIBUTE } from 'global/constants/attributes';
 
 import { version } from '../package.json';
 import { init } from './init';
+import { ATTRIBUTES } from './utils/constants';
 
 /**
  * Init
@@ -12,15 +13,16 @@ initAttributes();
 
 window.fsAttributes[GREENHOUSE_ATTRIBUTE] ||= {};
 
-const { preventsLoad } = assessScript();
-const attribute = window.fsAttributes[GREENHOUSE_ATTRIBUTE];
+const { preventsLoad, attributes } = assessScript({
+  board: ATTRIBUTES.board.key,
+  queryParam: ATTRIBUTES.queryparam.key,
+});
 
+const attribute = window.fsAttributes[GREENHOUSE_ATTRIBUTE];
 attribute.version = version;
 
 if (preventsLoad) attribute.init = init;
 else {
   window.Webflow ||= [];
-  window.Webflow.push(init);
+  window.Webflow.push(() => init(attributes));
 }
-
-(window as any).currentScript = document.currentScript;

--- a/packages/greenhouse/src/init.ts
+++ b/packages/greenhouse/src/init.ts
@@ -15,22 +15,24 @@ import { ATTRIBUTES, queryElement } from './utils/constants';
 /**
  * Inits the attribute.
  */
-export const init = async (): Promise<void> => {
+export const init = async ({
+  board,
+  queryParam,
+}: {
+  board: string | null;
+  queryParam?: string | null;
+}): Promise<void> => {
   await Promise.all([
     await window.fsAttributes[CMS_LOAD_ATTRIBUTE]?.loading,
     await window.fsAttributes[CMS_FILTER_ATTRIBUTE]?.loading,
     await window.fsAttributes[CMS_SORT_ATTRIBUTE]?.loading,
   ]);
 
-  const { currentScript } = window as any as { currentScript: HTMLScriptElement };
-
-  const board = currentScript.getAttribute(ATTRIBUTES.board.key);
+  queryParam ??= ATTRIBUTES.queryparam.default;
 
   if (!board) {
     return;
   }
-
-  const queryParam = currentScript.getAttribute(ATTRIBUTES.queryparam.key) || ATTRIBUTES.queryparam.default;
 
   const listJobsElements = queryElement<HTMLElement>(ATTRIBUTES.element.values.list, { all: true });
   const listJobsForms = queryElement<HTMLFormElement>(ATTRIBUTES.element.values.form, { all: true });


### PR DESCRIPTION
This PR includes an update to the `@global/factory/assess.ts` method `assessScript()`.
With this new update, we can read Attributes from the `<script>` tag by passing an object with the keys that have to be read.

Example:
```typescript
const test = assessScript({ board: 'fs-greenhouse-board', queryParam: 'fs-greenhouse-queryparam' });
// test:
 {
   preventsLoad: boolean;
   attributes: {
     board: string | null;
     queryParam: string | null;
    };
 }
```

Which can be then used like this:
```typescript
// index.ts
window.fsAttributes[GREENHOUSE_ATTRIBUTE] ||= {};

const { preventsLoad, attributes } = assessScript({
  board: ATTRIBUTES.board.key,
  queryParam: ATTRIBUTES.queryparam.key,
});

const attribute = window.fsAttributes[GREENHOUSE_ATTRIBUTE];
attribute.version = version;

if (preventsLoad) attribute.init = init;
else {
  window.Webflow ||= [];
  window.Webflow.push(() => init(attributes));
}
```

It's non-breaking for other Attributes as this new function argument is 100% optional.

@blessochampion I've tagged you because I believe this will improve the way you're currently reading the `<script>` Attributes in your `shopify` branch. Please check the changes in this PR to understand them.