### PR TITLE
updated template package

### DIFF
--- a/global/constants/attributes.ts
+++ b/global/constants/attributes.ts
@@ -1,5 +1,7 @@
 export const ATTRIBUTES_PREFIX = 'fs-attributes';
 
+export const EXAMPLE_ATTRIBUTE = 'example';
+
 export const A11Y_ATTRIBUTE = 'a11y';
 
 export const AUTO_VIDEO_ATTRIBUTE = 'autovideo';

--- a/packages/template/.changesets/v1.0.0.md
+++ b/packages/template/.changesets/v1.0.0.md
@@ -1,1 +1,0 @@
-- Created the attribute package.

--- a/packages/template/api/changesets.ts
+++ b/packages/template/api/changesets.ts
@@ -1,3 +1,7 @@
 import type { PartialAttributeChangesets } from '$global/types/changesets';
 
-export const changesets: PartialAttributeChangesets = [{ version: 'v1.0.0', date: '1 January 1970' }];
+/**
+ * @deprecated All changesets are now managed using the `@changesets/cli`.
+ * For more info, read the `Continuous Deployment` section in the root `README.md`.
+ */
+export const changesets: PartialAttributeChangesets = [];

--- a/packages/template/src/index.ts
+++ b/packages/template/src/index.ts
@@ -1,18 +1,18 @@
+import { EXAMPLE_ATTRIBUTE } from '$global/constants/attributes';
 import { assessScript, initAttributes } from '$global/factory';
 
 import { version } from '../package.json';
 import { init } from './init';
-import { ATTRIBUTE } from './utils/constants';
 
 /**
  * Init
  */
 initAttributes();
 
-window.fsAttributes[ATTRIBUTE] ||= {};
+window.fsAttributes[EXAMPLE_ATTRIBUTE] ||= {};
 
 const { preventsLoad } = assessScript();
-const attribute = window.fsAttributes[ATTRIBUTE];
+const attribute = window.fsAttributes[EXAMPLE_ATTRIBUTE];
 
 attribute.version = version;
 

--- a/packages/template/src/utils/constants.ts
+++ b/packages/template/src/utils/constants.ts
@@ -1,8 +1,7 @@
+import { EXAMPLE_ATTRIBUTE } from '$global/constants/attributes';
 import { generateSelectors } from '$global/factory';
 
-export const ATTRIBUTE = 'ATTRIBUTE_KEY';
-
-const ATTRIBUTES_PREFIX = `fs-${ATTRIBUTE}`;
+const ATTRIBUTES_PREFIX = `fs-${EXAMPLE_ATTRIBUTE}`;
 
 export const EXAMPLE_ELEMENT_KEY = 'example';
 export const EXAMPLE_SETTING_KEY = 'example';


### PR DESCRIPTION
I've updated the `template` package to include the latest codebase changes:
- Deprecation of the manual changesets. The `@changesets/cli` is used instead.
- Migrate the `ATTRIBUTE` constant definition to `global/constants/attributes.ts`.