### PR TITLE
`accordion`: Also include support for loaded items that are not appended to the DOM yet

### DIFF
--- a/.changeset/tiny-peaches-lick.md
+++ b/.changeset/tiny-peaches-lick.md
@@ -1,0 +1,5 @@
+---
+'@finsweet/attributes-accordion': patch
+---
+
+Follow up to v1.1.0: Also include support for loaded items that are not appended to the DOM yet, which can happen when combining accordion + cmsload + cmsfilter.

--- a/packages/accordion/src/actions/query.ts
+++ b/packages/accordion/src/actions/query.ts
@@ -1,6 +1,34 @@
+import type { CMSList } from '$packages/cmscore/src';
+
 import { queryElement } from '../utils/constants';
 
 /**
  * @returns All the accordion elements on the page.
+ * @param listInstances The `cmsload` instances. If provided, all the loaded accordions will also be added.
  */
-export const queryAllAccordions = () => queryElement<HTMLElement>('accordion', { operator: 'prefixed', all: true });
+export const queryAllAccordions = (listInstances?: CMSList[]) => {
+  const allAccordions = queryAccordions();
+
+  if (!listInstances) return allAccordions;
+
+  const allAccordionsSet = new Set(allAccordions);
+
+  for (const { items } of listInstances) {
+    for (const { element } of items) {
+      const accordions = queryAccordions(element);
+
+      for (const accordion of accordions) {
+        allAccordionsSet.add(accordion);
+      }
+    }
+  }
+
+  return [...allAccordionsSet];
+};
+
+/**
+ * @returns All the accordion children of an element.
+ * @param scope
+ */
+const queryAccordions = (scope?: Element) =>
+  queryElement<HTMLElement>('accordion', { scope, operator: 'prefixed', all: true });

--- a/packages/accordion/src/init.ts
+++ b/packages/accordion/src/init.ts
@@ -1,6 +1,7 @@
 import { ACCORDION_ATTRIBUTE, CMS_ATTRIBUTE_ATTRIBUTE, CMS_LOAD_ATTRIBUTE } from '$global/constants/attributes';
 import { awaitAttributesLoad, finalizeAttribute } from '$global/factory';
 import { importA11Y } from '$global/import/a11y';
+import type { CMSList } from '$packages/cmscore/src';
 
 import { queryAllAccordions } from './actions/query';
 import { initAccordionGroups } from './factory';
@@ -18,9 +19,9 @@ export const init = async () => {
   // Wait for CMSLoad to render all accordions, only if required
   const usesCMSLoad = accordions.some((accordion) => accordion.closest(CMS_LOAD_LIST_ELEMENT_SELECTOR));
   if (usesCMSLoad) {
-    await awaitAttributesLoad(CMS_LOAD_ATTRIBUTE);
+    const listInstances: CMSList[] = (await awaitAttributesLoad(CMS_LOAD_ATTRIBUTE))[0];
 
-    accordions = queryAllAccordions();
+    accordions = queryAllAccordions(listInstances);
   }
 
   // Init all groups


### PR DESCRIPTION
Follow up to #294 : Also include support for loaded items that are not appended to the DOM yet, which can happen when combining accordion + cmsload + cmsfilter.