### PR TITLE
disable `support` package

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,3 +3,4 @@ packages:
   - 'packages/*'
   - '!packages/cmssave'
   - '!packages/template'
+  - '!packages/support'


### PR DESCRIPTION
@mauriciopiber CI runs horribly slow because of the `@finsweet/attributes-support` package.
I'm disabling it from the workspace until we need to work on it again.
For a future `v2` we should definetely switch that package to use `vite` and `vitest`, it will speed up everything by orders of magnitude.