### PR TITLE
global: allow using instance wrappers

### DIFF
--- a/packages/utils/src/helpers/selectors.ts
+++ b/packages/utils/src/helpers/selectors.ts
@@ -73,9 +73,14 @@ export const generateSelectors = <
     }
 
     const elementSelector = `[${ELEMENT_ATTRIBUTE_NAME}="${elementKey}" i]`;
-    const instanceSelector = isNumber(instanceIndex) ? `[${INSTANCE_ATTRIBUTE_NAME}="${instanceIndex}"]` : '';
 
-    return elementSelector + instanceSelector;
+    if (!isNumber(instanceIndex)) {
+      return elementSelector;
+    }
+
+    const instanceSelector = `[${INSTANCE_ATTRIBUTE_NAME}="${instanceIndex}"]`;
+
+    return `${elementSelector}${instanceSelector}, ${instanceSelector} ${elementSelector}`;
   };
 
   /**


### PR DESCRIPTION
Minor tweak to treat instances as the other settings, bubbling up to match the first parent that matches the instance index.
See video for explanation:
https://www.loom.com/share/534dc567bd6b4baea03d5d6a57a6b579?sid=8fb9ae42-dc8a-4130-bad8-63bf30ac79f5