### PR TITLE
Linting improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,12 +6,11 @@
   "scripts": {
     "dev": "pnpm --filter @finsweet/attributes dev",
     "build": "pnpm --filter @finsweet/attributes build",
-    "check": "pnpm --filter @finsweet/attributes check",
-    "lint": "eslint ./packages && prettier --check ./packages",
-    "lint:fix": "eslint ./packages --fix",
-    "format": "prettier --write ./packages",
-    "test": "pnpm --filter @finsweet/attributes test --workspace-concurrency=1",
-    "test:headed": "pnpm --filter @finsweet/attributes test:headed --workspace-concurrency=1",
+    "check": "pnpm -r check",
+    "lint": "pnpm -r lint",
+    "lint:fix": "pnpm -r lint:fix",
+    "test": "pnpm --filter @finsweet/attributes test",
+    "test:headed": "pnpm --filter @finsweet/attributes test:headed",
     "release": "changeset publish",
     "update": "pnpm update -i -L -r"
   },

--- a/packages/a11y/package.json
+++ b/packages/a11y/package.json
@@ -5,6 +5,11 @@
   "private": true,
   "type": "module",
   "types": "src/index.ts",
+  "scripts": {
+    "lint": "eslint ./src && prettier --check ./src",
+    "lint:fix": "eslint ./src --fix && prettier --write ./src",
+    "check": "tsc --noEmit"
+  },
   "exports": {
     ".": {
       "types": "./src/index.ts",

--- a/packages/accordion/package.json
+++ b/packages/accordion/package.json
@@ -5,6 +5,11 @@
   "private": true,
   "type": "module",
   "types": "src/index.ts",
+  "scripts": {
+    "lint": "eslint ./src && prettier --check ./src",
+    "lint:fix": "eslint ./src --fix && prettier --write ./src",
+    "check": "tsc --noEmit"
+  },
   "exports": {
     ".": {
       "types": "./src/index.ts",

--- a/packages/attributes/package.json
+++ b/packages/attributes/package.json
@@ -15,7 +15,7 @@
     "dev": "cross-env NODE_ENV=development tsx ./bin/build.ts",
     "build": "cross-env NODE_ENV=production tsx ./bin/build.ts",
     "lint": "eslint ./src && prettier --check ./src",
-    "lint:fix": "eslint ./src --fix",
+    "lint:fix": "eslint ./src --fix && prettier --write ./src",
     "check": "tsc --noEmit",
     "test": "pnpm playwright test",
     "test:headed": "pnpm playwright test --headed"

--- a/packages/autovideo/package.json
+++ b/packages/autovideo/package.json
@@ -5,6 +5,11 @@
   "private": true,
   "type": "module",
   "types": "src/index.ts",
+  "scripts": {
+    "lint": "eslint ./src && prettier --check ./src",
+    "lint:fix": "eslint ./src --fix && prettier --write ./src",
+    "check": "tsc --noEmit"
+  },
   "exports": {
     ".": {
       "types": "./src/index.ts",

--- a/packages/cmscombine/package.json
+++ b/packages/cmscombine/package.json
@@ -5,6 +5,11 @@
   "private": true,
   "type": "module",
   "types": "src/index.ts",
+  "scripts": {
+    "lint": "eslint ./src && prettier --check ./src",
+    "lint:fix": "eslint ./src --fix && prettier --write ./src",
+    "check": "tsc --noEmit"
+  },
   "exports": {
     ".": {
       "types": "./src/index.ts",

--- a/packages/cmscore/package.json
+++ b/packages/cmscore/package.json
@@ -4,6 +4,11 @@
   "private": true,
   "type": "module",
   "types": "src/index.ts",
+  "scripts": {
+    "lint": "eslint ./src && prettier --check ./src",
+    "lint:fix": "eslint ./src --fix && prettier --write ./src",
+    "check": "tsc --noEmit"
+  },
   "exports": {
     ".": {
       "types": "./src/index.ts",

--- a/packages/cmsfilter/package.json
+++ b/packages/cmsfilter/package.json
@@ -5,6 +5,11 @@
   "private": true,
   "type": "module",
   "types": "src/index.ts",
+  "scripts": {
+    "lint": "eslint ./src && prettier --check ./src",
+    "lint:fix": "eslint ./src --fix && prettier --write ./src",
+    "check": "tsc --noEmit"
+  },
   "exports": {
     ".": {
       "types": "./src/index.ts",

--- a/packages/cmsload/package.json
+++ b/packages/cmsload/package.json
@@ -5,6 +5,11 @@
   "private": true,
   "type": "module",
   "types": "src/index.ts",
+  "scripts": {
+    "lint": "eslint ./src && prettier --check ./src",
+    "lint:fix": "eslint ./src --fix && prettier --write ./src",
+    "check": "tsc --noEmit"
+  },
   "exports": {
     ".": {
       "types": "./src/index.ts",

--- a/packages/cmsnest/package.json
+++ b/packages/cmsnest/package.json
@@ -5,6 +5,11 @@
   "private": true,
   "type": "module",
   "types": "src/index.ts",
+  "scripts": {
+    "lint": "eslint ./src && prettier --check ./src",
+    "lint:fix": "eslint ./src --fix && prettier --write ./src",
+    "check": "tsc --noEmit"
+  },
   "exports": {
     ".": {
       "types": "./src/index.ts",

--- a/packages/cmsprevnext/package.json
+++ b/packages/cmsprevnext/package.json
@@ -5,6 +5,11 @@
   "private": true,
   "type": "module",
   "types": "src/index.ts",
+  "scripts": {
+    "lint": "eslint ./src && prettier --check ./src",
+    "lint:fix": "eslint ./src --fix && prettier --write ./src",
+    "check": "tsc --noEmit"
+  },
   "exports": {
     ".": {
       "types": "./src/index.ts",

--- a/packages/cmsselect/package.json
+++ b/packages/cmsselect/package.json
@@ -5,6 +5,11 @@
   "private": true,
   "type": "module",
   "types": "src/index.ts",
+  "scripts": {
+    "lint": "eslint ./src && prettier --check ./src",
+    "lint:fix": "eslint ./src --fix && prettier --write ./src",
+    "check": "tsc --noEmit"
+  },
   "exports": {
     ".": {
       "types": "./src/index.ts",

--- a/packages/cmsslider/package.json
+++ b/packages/cmsslider/package.json
@@ -5,6 +5,11 @@
   "private": true,
   "type": "module",
   "types": "src/index.ts",
+  "scripts": {
+    "lint": "eslint ./src && prettier --check ./src",
+    "lint:fix": "eslint ./src --fix && prettier --write ./src",
+    "check": "tsc --noEmit"
+  },
   "exports": {
     ".": {
       "types": "./src/index.ts",

--- a/packages/cmssort/package.json
+++ b/packages/cmssort/package.json
@@ -5,6 +5,11 @@
   "private": true,
   "type": "module",
   "types": "src/index.ts",
+  "scripts": {
+    "lint": "eslint ./src && prettier --check ./src",
+    "lint:fix": "eslint ./src --fix && prettier --write ./src",
+    "check": "tsc --noEmit"
+  },
   "exports": {
     ".": {
       "types": "./src/index.ts",

--- a/packages/cmsstatic/package.json
+++ b/packages/cmsstatic/package.json
@@ -5,6 +5,11 @@
   "private": true,
   "type": "module",
   "types": "src/index.ts",
+  "scripts": {
+    "lint": "eslint ./src && prettier --check ./src",
+    "lint:fix": "eslint ./src --fix && prettier --write ./src",
+    "check": "tsc --noEmit"
+  },
   "exports": {
     ".": {
       "types": "./src/index.ts",

--- a/packages/cmstabs/package.json
+++ b/packages/cmstabs/package.json
@@ -5,6 +5,11 @@
   "private": true,
   "type": "module",
   "types": "src/index.ts",
+  "scripts": {
+    "lint": "eslint ./src && prettier --check ./src",
+    "lint:fix": "eslint ./src --fix && prettier --write ./src",
+    "check": "tsc --noEmit"
+  },
   "exports": {
     ".": {
       "types": "./src/index.ts",

--- a/packages/codehighlight/package.json
+++ b/packages/codehighlight/package.json
@@ -5,6 +5,11 @@
   "private": true,
   "type": "module",
   "types": "src/index.ts",
+  "scripts": {
+    "lint": "eslint ./src && prettier --check ./src",
+    "lint:fix": "eslint ./src --fix && prettier --write ./src",
+    "check": "tsc --noEmit"
+  },
   "exports": {
     ".": {
       "types": "./src/index.ts",

--- a/packages/combobox/package.json
+++ b/packages/combobox/package.json
@@ -5,6 +5,11 @@
   "private": true,
   "type": "module",
   "types": "src/index.ts",
+  "scripts": {
+    "lint": "eslint ./src && prettier --check ./src",
+    "lint:fix": "eslint ./src --fix && prettier --write ./src",
+    "check": "tsc --noEmit"
+  },
   "exports": {
     ".": {
       "types": "./src/index.ts",

--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -5,6 +5,11 @@
   "private": true,
   "type": "module",
   "types": "src/index.ts",
+  "scripts": {
+    "lint": "eslint ./src && prettier --check ./src",
+    "lint:fix": "eslint ./src --fix && prettier --write ./src",
+    "check": "tsc --noEmit"
+  },
   "exports": {
     ".": {
       "types": "./src/index.ts",

--- a/packages/consent/package.json
+++ b/packages/consent/package.json
@@ -5,6 +5,11 @@
   "private": true,
   "type": "module",
   "types": "src/index.ts",
+  "scripts": {
+    "lint": "eslint ./src && prettier --check ./src",
+    "lint:fix": "eslint ./src --fix && prettier --write ./src",
+    "check": "tsc --noEmit"
+  },
   "exports": {
     ".": {
       "types": "./src/index.ts",

--- a/packages/copyclip/package.json
+++ b/packages/copyclip/package.json
@@ -5,6 +5,11 @@
   "private": true,
   "type": "module",
   "types": "src/index.ts",
+  "scripts": {
+    "lint": "eslint ./src && prettier --check ./src",
+    "lint:fix": "eslint ./src --fix && prettier --write ./src",
+    "check": "tsc --noEmit"
+  },
   "exports": {
     ".": {
       "types": "./src/index.ts",

--- a/packages/countitems/package.json
+++ b/packages/countitems/package.json
@@ -5,6 +5,11 @@
   "private": true,
   "type": "module",
   "types": "src/index.ts",
+  "scripts": {
+    "lint": "eslint ./src && prettier --check ./src",
+    "lint:fix": "eslint ./src --fix && prettier --write ./src",
+    "check": "tsc --noEmit"
+  },
   "exports": {
     ".": {
       "types": "./src/index.ts",

--- a/packages/displayvalues/package.json
+++ b/packages/displayvalues/package.json
@@ -5,6 +5,11 @@
   "private": true,
   "type": "module",
   "types": "src/index.ts",
+  "scripts": {
+    "lint": "eslint ./src && prettier --check ./src",
+    "lint:fix": "eslint ./src --fix && prettier --write ./src",
+    "check": "tsc --noEmit"
+  },
   "exports": {
     ".": {
       "types": "./src/index.ts",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -20,7 +20,7 @@
     "build:dev": "cross-env NODE_ENV=test node ./bin/build.js",
     "build": "cross-env NODE_ENV=production node ./bin/build.js",
     "lint": "eslint ./src && prettier --check ./src",
-    "lint:fix": "eslint ./src --fix",
+    "lint:fix": "eslint ./src --fix && prettier --write ./src",
     "check": "tsc --noEmit",
     "format": "prettier --write ./src",
     "test": "pnpm playwright test",

--- a/packages/docs/src/api/index.ts
+++ b/packages/docs/src/api/index.ts
@@ -1,6 +1,6 @@
+import { CODE_HIGHLIGHT_ATTRIBUTE, TOC_ATTRIBUTE } from '@finsweet/attributes-utils';
 import { marked } from 'marked';
 
-import { CODE_HIGHLIGHT_ATTRIBUTE, TOC_ATTRIBUTE } from '$global/constants/attributes';
 import { queryElement as queryTOCElement } from '$packages/toc/src/utils/constants';
 
 import attributesData from '../../api/attributes';
@@ -27,6 +27,6 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   contentsElement.innerHTML = marked.parse(markdown);
 
-  window.fsAttributes[CODE_HIGHLIGHT_ATTRIBUTE].init?.();
-  window.fsAttributes[TOC_ATTRIBUTE]?.init?.();
+  window.fsAttributes.solutions[CODE_HIGHLIGHT_ATTRIBUTE].init?.();
+  window.fsAttributes.solutions[TOC_ATTRIBUTE]?.init?.();
 });

--- a/packages/favcustom/package.json
+++ b/packages/favcustom/package.json
@@ -5,6 +5,11 @@
   "private": true,
   "type": "module",
   "types": "src/index.ts",
+  "scripts": {
+    "lint": "eslint ./src && prettier --check ./src",
+    "lint:fix": "eslint ./src --fix && prettier --write ./src",
+    "check": "tsc --noEmit"
+  },
   "exports": {
     ".": {
       "types": "./src/index.ts",

--- a/packages/formsubmit/package.json
+++ b/packages/formsubmit/package.json
@@ -5,6 +5,11 @@
   "private": true,
   "type": "module",
   "types": "src/index.ts",
+  "scripts": {
+    "lint": "eslint ./src && prettier --check ./src",
+    "lint:fix": "eslint ./src --fix && prettier --write ./src",
+    "check": "tsc --noEmit"
+  },
   "exports": {
     ".": {
       "types": "./src/index.ts",

--- a/packages/greenhouse/package.json
+++ b/packages/greenhouse/package.json
@@ -5,6 +5,11 @@
   "private": true,
   "type": "module",
   "types": "src/index.ts",
+  "scripts": {
+    "lint": "eslint ./src && prettier --check ./src",
+    "lint:fix": "eslint ./src --fix && prettier --write ./src",
+    "check": "tsc --noEmit"
+  },
   "exports": {
     ".": {
       "types": "./src/index.ts",

--- a/packages/inputactive/package.json
+++ b/packages/inputactive/package.json
@@ -5,6 +5,11 @@
   "private": true,
   "type": "module",
   "types": "src/index.ts",
+  "scripts": {
+    "lint": "eslint ./src && prettier --check ./src",
+    "lint:fix": "eslint ./src --fix && prettier --write ./src",
+    "check": "tsc --noEmit"
+  },
   "exports": {
     ".": {
       "types": "./src/index.ts",

--- a/packages/inputcounter/package.json
+++ b/packages/inputcounter/package.json
@@ -5,6 +5,11 @@
   "private": true,
   "type": "module",
   "types": "src/index.ts",
+  "scripts": {
+    "lint": "eslint ./src && prettier --check ./src",
+    "lint:fix": "eslint ./src --fix && prettier --write ./src",
+    "check": "tsc --noEmit"
+  },
   "exports": {
     ".": {
       "types": "./src/index.ts",

--- a/packages/launchdarkly/package.json
+++ b/packages/launchdarkly/package.json
@@ -5,6 +5,11 @@
   "private": true,
   "type": "module",
   "types": "src/index.ts",
+  "scripts": {
+    "lint": "eslint ./src && prettier --check ./src",
+    "lint:fix": "eslint ./src --fix && prettier --write ./src",
+    "check": "tsc --noEmit"
+  },
   "exports": {
     ".": {
       "types": "./src/index.ts",

--- a/packages/linkblockedit/package.json
+++ b/packages/linkblockedit/package.json
@@ -5,6 +5,11 @@
   "private": true,
   "type": "module",
   "types": "src/index.ts",
+  "scripts": {
+    "lint": "eslint ./src && prettier --check ./src",
+    "lint:fix": "eslint ./src --fix && prettier --write ./src",
+    "check": "tsc --noEmit"
+  },
   "exports": {
     ".": {
       "types": "./src/index.ts",

--- a/packages/mirrorclick/package.json
+++ b/packages/mirrorclick/package.json
@@ -5,6 +5,11 @@
   "private": true,
   "type": "module",
   "types": "src/index.ts",
+  "scripts": {
+    "lint": "eslint ./src && prettier --check ./src",
+    "lint:fix": "eslint ./src --fix && prettier --write ./src",
+    "check": "tsc --noEmit"
+  },
   "exports": {
     ".": {
       "types": "./src/index.ts",

--- a/packages/mirrorinput/package.json
+++ b/packages/mirrorinput/package.json
@@ -5,6 +5,11 @@
   "private": true,
   "type": "module",
   "types": "src/index.ts",
+  "scripts": {
+    "lint": "eslint ./src && prettier --check ./src",
+    "lint:fix": "eslint ./src --fix && prettier --write ./src",
+    "check": "tsc --noEmit"
+  },
   "exports": {
     ".": {
       "types": "./src/index.ts",

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -5,6 +5,11 @@
   "private": true,
   "type": "module",
   "types": "src/index.ts",
+  "scripts": {
+    "lint": "eslint ./src && prettier --check ./src",
+    "lint:fix": "eslint ./src --fix && prettier --write ./src",
+    "check": "tsc --noEmit"
+  },
   "exports": {
     ".": {
       "types": "./src/index.ts",

--- a/packages/numbercount/package.json
+++ b/packages/numbercount/package.json
@@ -5,6 +5,11 @@
   "private": true,
   "type": "module",
   "types": "src/index.ts",
+  "scripts": {
+    "lint": "eslint ./src && prettier --check ./src",
+    "lint:fix": "eslint ./src --fix && prettier --write ./src",
+    "check": "tsc --noEmit"
+  },
   "exports": {
     ".": {
       "types": "./src/index.ts",

--- a/packages/queryparam/package.json
+++ b/packages/queryparam/package.json
@@ -5,6 +5,11 @@
   "private": true,
   "type": "module",
   "types": "src/index.ts",
+  "scripts": {
+    "lint": "eslint ./src && prettier --check ./src",
+    "lint:fix": "eslint ./src --fix && prettier --write ./src",
+    "check": "tsc --noEmit"
+  },
   "exports": {
     ".": {
       "types": "./src/index.ts",

--- a/packages/rangeslider/package.json
+++ b/packages/rangeslider/package.json
@@ -5,6 +5,11 @@
   "private": true,
   "type": "module",
   "types": "src/index.ts",
+  "scripts": {
+    "lint": "eslint ./src && prettier --check ./src",
+    "lint:fix": "eslint ./src --fix && prettier --write ./src",
+    "check": "tsc --noEmit"
+  },
   "exports": {
     ".": {
       "types": "./src/index.ts",

--- a/packages/readtime/package.json
+++ b/packages/readtime/package.json
@@ -5,6 +5,11 @@
   "private": true,
   "type": "module",
   "types": "src/index.ts",
+  "scripts": {
+    "lint": "eslint ./src && prettier --check ./src",
+    "lint:fix": "eslint ./src --fix && prettier --write ./src",
+    "check": "tsc --noEmit"
+  },
   "exports": {
     ".": {
       "types": "./src/index.ts",

--- a/packages/richtext/package.json
+++ b/packages/richtext/package.json
@@ -5,6 +5,11 @@
   "private": true,
   "type": "module",
   "types": "src/index.ts",
+  "scripts": {
+    "lint": "eslint ./src && prettier --check ./src",
+    "lint:fix": "eslint ./src --fix && prettier --write ./src",
+    "check": "tsc --noEmit"
+  },
   "exports": {
     ".": {
       "types": "./src/index.ts",

--- a/packages/scrolldisable/package.json
+++ b/packages/scrolldisable/package.json
@@ -5,6 +5,11 @@
   "private": true,
   "type": "module",
   "types": "src/index.ts",
+  "scripts": {
+    "lint": "eslint ./src && prettier --check ./src",
+    "lint:fix": "eslint ./src --fix && prettier --write ./src",
+    "check": "tsc --noEmit"
+  },
   "exports": {
     ".": {
       "types": "./src/index.ts",

--- a/packages/selectcustom/package.json
+++ b/packages/selectcustom/package.json
@@ -5,6 +5,11 @@
   "private": true,
   "type": "module",
   "types": "src/index.ts",
+  "scripts": {
+    "lint": "eslint ./src && prettier --check ./src",
+    "lint:fix": "eslint ./src --fix && prettier --write ./src",
+    "check": "tsc --noEmit"
+  },
   "exports": {
     ".": {
       "types": "./src/index.ts",

--- a/packages/slider/package.json
+++ b/packages/slider/package.json
@@ -5,6 +5,11 @@
   "private": true,
   "type": "module",
   "types": "src/index.ts",
+  "scripts": {
+    "lint": "eslint ./src && prettier --check ./src",
+    "lint:fix": "eslint ./src --fix && prettier --write ./src",
+    "check": "tsc --noEmit"
+  },
   "exports": {
     ".": {
       "types": "./src/index.ts",

--- a/packages/slider/src/utils/schema.ts
+++ b/packages/slider/src/utils/schema.ts
@@ -251,7 +251,7 @@ export const SCHEMA: Schema<typeof ELEMENTS, typeof SETTINGS> = {
       ],
     },
     {
-      key: 'pagination-current',
+      key: 'count-current',
       name: 'Count Current',
       description: 'Defines the Count Current element.',
       allowedTypes: ['Block'],
@@ -264,7 +264,7 @@ export const SCHEMA: Schema<typeof ELEMENTS, typeof SETTINGS> = {
       ],
     },
     {
-      key: 'pagination-total',
+      key: 'count-total',
       name: 'Count Total',
       description: 'Defines the Count Total element.',
       allowedTypes: ['Block'],

--- a/packages/sliderdots/package.json
+++ b/packages/sliderdots/package.json
@@ -5,6 +5,11 @@
   "private": true,
   "type": "module",
   "types": "src/index.ts",
+  "scripts": {
+    "lint": "eslint ./src && prettier --check ./src",
+    "lint:fix": "eslint ./src --fix && prettier --write ./src",
+    "check": "tsc --noEmit"
+  },
   "exports": {
     ".": {
       "types": "./src/index.ts",

--- a/packages/smartlightbox/package.json
+++ b/packages/smartlightbox/package.json
@@ -5,6 +5,11 @@
   "private": true,
   "type": "module",
   "types": "src/index.ts",
+  "scripts": {
+    "lint": "eslint ./src && prettier --check ./src",
+    "lint:fix": "eslint ./src --fix && prettier --write ./src",
+    "check": "tsc --noEmit"
+  },
   "exports": {
     ".": {
       "types": "./src/index.ts",

--- a/packages/socialshare/package.json
+++ b/packages/socialshare/package.json
@@ -5,6 +5,11 @@
   "private": true,
   "type": "module",
   "types": "src/index.ts",
+  "scripts": {
+    "lint": "eslint ./src && prettier --check ./src",
+    "lint:fix": "eslint ./src --fix && prettier --write ./src",
+    "check": "tsc --noEmit"
+  },
   "exports": {
     ".": {
       "types": "./src/index.ts",

--- a/packages/starrating/package.json
+++ b/packages/starrating/package.json
@@ -5,6 +5,11 @@
   "private": true,
   "type": "module",
   "types": "src/index.ts",
+  "scripts": {
+    "lint": "eslint ./src && prettier --check ./src",
+    "lint:fix": "eslint ./src --fix && prettier --write ./src",
+    "check": "tsc --noEmit"
+  },
   "exports": {
     ".": {
       "types": "./src/index.ts",

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -5,6 +5,11 @@
   "private": true,
   "type": "module",
   "types": "src/index.ts",
+  "scripts": {
+    "lint": "eslint ./src && prettier --check ./src",
+    "lint:fix": "eslint ./src --fix && prettier --write ./src",
+    "check": "tsc --noEmit"
+  },
   "exports": {
     ".": {
       "types": "./src/index.ts",

--- a/packages/toc/package.json
+++ b/packages/toc/package.json
@@ -5,6 +5,11 @@
   "private": true,
   "type": "module",
   "types": "src/index.ts",
+  "scripts": {
+    "lint": "eslint ./src && prettier --check ./src",
+    "lint:fix": "eslint ./src --fix && prettier --write ./src",
+    "check": "tsc --noEmit"
+  },
   "exports": {
     ".": {
       "types": "./src/index.ts",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -6,6 +6,11 @@
   "sideEffects": false,
   "type": "module",
   "types": "src/index.ts",
+  "scripts": {
+    "lint": "eslint ./src && prettier --check ./src",
+    "lint:fix": "eslint ./src --fix && prettier --write ./src",
+    "check": "tsc --noEmit"
+  },
   "exports": {
     ".": {
       "types": "./src/index.ts",

--- a/packages/videohls/package.json
+++ b/packages/videohls/package.json
@@ -5,6 +5,11 @@
   "private": true,
   "type": "module",
   "types": "src/index.ts",
+  "scripts": {
+    "lint": "eslint ./src && prettier --check ./src",
+    "lint:fix": "eslint ./src --fix && prettier --write ./src",
+    "check": "tsc --noEmit"
+  },
   "exports": {
     ".": {
       "types": "./src/index.ts",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 packages:
   - 'packages/*'
+  - '!packages/docs'
   - '!packages/template'


### PR DESCRIPTION
- Moves linting scripts into each package for better control over failures.
- Temporarily disables the `docs` package from the workspace until we update it for the `v2` docs.

@robertkibet , @Dovbaka , @michaelgatuma please update your branches after this has been merged and include the linting scripts into any missing package.