### PR TITLE
fix: global settings in attributes init

### DIFF
--- a/packages/attributes/src/init.ts
+++ b/packages/attributes/src/init.ts
@@ -109,7 +109,7 @@ const initAttribute = async (
     // only if they were not explicitly provided via the API import
     if (!globalSettings && script) {
       const globalSettingsEntries = Object.entries(SETTINGS).reduce<[string, string][]>((acc, [, { key }]) => {
-        const value = script.getAttribute(`fs-${key}`);
+        const value = script.getAttribute(`fs-${attribute}-${key}`);
         if (!value) return acc;
 
         acc.push([key, value]);


### PR DESCRIPTION
Global settings added to the `<script>` tags like `fs-component-proxy` in this example were not working correctly:
```html
<script async type="module" fs-component fs-component-proxy="https://api.finsweet.com/cors?url=" src="http://localhost:3000/dist/index.js"></script>
```