### PR TITLE
(`v2`) fix: race conditions when cmssort and cmsload are combined

### DIFF
--- a/packages/cmssort/src/factory.ts
+++ b/packages/cmssort/src/factory.ts
@@ -21,7 +21,7 @@ import type { CSSClasses } from './utils/types';
  *
  * @returns A cleanup callback.
  */
-export const initListSorting = async (listInstance: CMSList) => {
+export const initListSorting = (listInstance: CMSList) => {
   const { listOrWrapper } = listInstance;
 
   const instanceIndex = getInstanceIndex(listOrWrapper);
@@ -59,7 +59,7 @@ export const initListSorting = async (listInstance: CMSList) => {
   const isDropdown = firstTrigger.closest<Dropdown>(`.${DROPDOWN_CSS_CLASSES.dropdown}`);
 
   const sortActions = isSelect
-    ? await initHTMLSelect(firstTrigger, listInstance)
+    ? initHTMLSelect(firstTrigger, listInstance)
     : isDropdown
     ? initDropdown(isDropdown, listInstance)
     : initButtons(triggers, listInstance, cssClasses);

--- a/packages/cmssort/src/init.ts
+++ b/packages/cmssort/src/init.ts
@@ -12,9 +12,7 @@ export const init: FsAttributeInit = async () => {
 
   const listInstances = createCMSListInstances([getElementSelector('list')]);
 
-  const cleanups = (await Promise.all(listInstances.map((listInstance) => initListSorting(listInstance)))).filter(
-    isNotEmpty
-  );
+  const cleanups = listInstances.map(initListSorting).filter(isNotEmpty);
 
   return {
     result: listInstances,

--- a/packages/cmssort/src/modes/select.ts
+++ b/packages/cmssort/src/modes/select.ts
@@ -9,7 +9,7 @@ import type { SortingDirection, SortItemsCallback } from '../utils/types';
  * @param selectElement The {@link HTMLSelectElement}.
  * @param listInstance The {@link CMSList} instance.
  */
-export const initHTMLSelect = async (selectElement: HTMLSelectElement, listInstance: CMSList) => {
+export const initHTMLSelect = (selectElement: HTMLSelectElement, listInstance: CMSList) => {
   let [sortKey, direction] = getSortingParams(selectElement.value);
   let sorting = false;
 
@@ -36,7 +36,7 @@ export const initHTMLSelect = async (selectElement: HTMLSelectElement, listInsta
   });
 
   // Sort items if a sortKey exists on page load
-  if (sortKey) await sortItems();
+  if (sortKey) sortItems();
 
   // Prevent submit events on the form
   const form = selectElement.closest('form');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true
@@ -412,19 +412,6 @@ importers:
       '@finsweet/attributes-utils':
         specifier: workspace:*
         version: link:../utils
-
-  packages/docs:
-    dependencies:
-      '@finsweet/attributes-utils':
-        specifier: workspace:*
-        version: link:../utils
-      marked:
-        specifier: ^5.1.0
-        version: 5.1.0
-    devDependencies:
-      '@types/marked':
-        specifier: ^5.0.0
-        version: 5.0.0
 
   packages/favcustom:
     dependencies:
@@ -1494,10 +1481,6 @@ packages:
 
   /@types/json-schema@7.0.12:
     resolution: {integrity: sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==}
-    dev: true
-
-  /@types/marked@5.0.0:
-    resolution: {integrity: sha512-YcZe50jhltsCq7rc9MNZC/4QB/OnA2Pd6hrOSTOFajtabN+38slqgDDCeE/0F83SjkKBQcsZUj7VLWR0H5cKRA==}
     dev: true
 
   /@types/minimist@1.2.2:
@@ -3008,12 +2991,6 @@ packages:
     resolution: {integrity: sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==}
     engines: {node: '>=8'}
     dev: true
-
-  /marked@5.1.0:
-    resolution: {integrity: sha512-z3/nBe7aTI8JDszlYLk7dDVNpngjw0o1ZJtrA9kIfkkHcIF+xH7mO23aISl4WxP83elU+MFROgahqdpd05lMEQ==}
-    engines: {node: '>= 18'}
-    hasBin: true
-    dev: false
 
   /meow@6.1.1:
     resolution: {integrity: sha512-3YffViIt2QWgTy6Pale5QpopX/IvU3LPL03jOTqp6pGj3VjesdO/U8CuHMKpnQr4shCNCM5fd5XFFvIIl6JBHg==}


### PR DESCRIPTION
Implements same #448 PR but for `v2`.