### PR TITLE
fix: rendering the TOC breaks on iOS 17

### DIFF
--- a/.changeset/lucky-mirrors-wave.md
+++ b/.changeset/lucky-mirrors-wave.md
@@ -1,0 +1,5 @@
+---
+'@finsweet/attributes-toc': patch
+---
+
+fix: rendering the TOC breaks on iOS 17

--- a/packages/toc/src/actions/collect.ts
+++ b/packages/toc/src/actions/collect.ts
@@ -21,6 +21,8 @@ export const collectHeadingsData = ({ children }: HTMLElement) => {
 
   for (let i = children.length - 1; i >= 0; i--) {
     const child = children[i];
+    if (!child) continue;
+
     const headingElement = child.closest<HTMLParagraphElement>(ALLOWED_HEADINGS_SELECTOR);
     if (!headingElement) continue;
 


### PR DESCRIPTION
Closes #477 