### PR TITLE
feat: match entire text entered in a text input with `match="all"` option

### DIFF
--- a/packages/cmsfilter/src/actions/filter.ts
+++ b/packages/cmsfilter/src/actions/filter.ts
@@ -107,7 +107,8 @@ const checkFilterValidity = (
           filterElements.some(({ type }) => !['checkbox', 'radio', 'select-one'].includes(type)) ||
           filterKeys.length > 1
         ) {
-          isValid = propValue.toLowerCase().includes(filterValue.toLowerCase());
+          if (match === 'all') isValid = filterValue.toLowerCase() === propValue.toLowerCase();
+          else isValid = propValue.toLowerCase().includes(filterValue.toLowerCase());
         }
 
         // Multiple Prop Values
@@ -123,6 +124,9 @@ const checkFilterValidity = (
 
     return match === 'all' ? matchingFilterValues.length === filterValues.length : matchingFilterValues.length > 0;
   });
+
+  if (filterElements.some(({ type }) => !['checkbox', 'radio', 'select-one'].includes(type)) && match === 'all')
+    return validFilterKeys.length > 0;
 
   return match === 'all' ? validFilterKeys.length === filterKeys.length : validFilterKeys.length > 0;
 };


### PR DESCRIPTION
## feat: match all text typed in a text input when `match` option is defined with `all`
Currently, cmsfilter v1 cannot match all text entered in  a search field.
Merging this PR will add that functionality such that adding `fs-cmsfilter-match="all"` to an input field will only filter cms items that match the exact text entered in the input field.

See the below discussion on slack:
![image](https://github.com/finsweet/attributes/assets/50529359/1bec3a63-c1fd-4efd-b6c3-afd49e53e433)

After merging this PR, adding `fs-cmsfilter-match="all"` to the search field and searching for **Chocolate** will only return one CMS item with **chocolate**, whereas a search for **Choco** will not return anything.