### PR TITLE
fix: remove double backslash on linkedin share link

### DIFF
--- a/.changeset/fluffy-flowers-cross.md
+++ b/.changeset/fluffy-flowers-cross.md
@@ -1,0 +1,5 @@
+---
+'@finsweet/attributes-socialshare': patch
+---
+
+fix: remove double backslash on linkedin link

--- a/packages/socialshare/src/utils/constants.ts
+++ b/packages/socialshare/src/utils/constants.ts
@@ -101,6 +101,6 @@ export const SOCIAL_SHARE_PLATFORMS = {
   twitter: 'https://twitter.com/intent/tweet/',
   pinterest: 'https://www.pinterest.com/pin/create/trigger/',
   reddit: 'https://www.reddit.com/submit',
-  linkedin: 'https://www.linkedin.com//sharing/share-offsite',
+  linkedin: 'https://www.linkedin.com/sharing/share-offsite',
   telegram: 'https://t.me/share',
 } as const;


### PR DESCRIPTION
Ref: https://forum.finsweet.com/t/social-share-linkedin-gives-me-an-error/1973