### PR TITLE
feat: support v1 richtext syntax OOO

### DIFF
--- a/.changeset/itchy-ads-sip.md
+++ b/.changeset/itchy-ads-sip.md
@@ -1,0 +1,5 @@
+---
+'@finsweet/attributes-inject': minor
+---
+
+feat: support v1 richtext syntax OOO

--- a/packages/inject/src/actions/css.ts
+++ b/packages/inject/src/actions/css.ts
@@ -1,3 +1,5 @@
+import { cloneNode } from '@finsweet/attributes-utils';
+
 /**
  * Attaches the page styles to a Shadow DOM.
  * @param shadowRoot The root of the Shadow DOM.
@@ -11,9 +13,11 @@ export const attachPageStyles = async (shadowRoot: ShadowRoot, page: Document) =
     styleTags.map(
       (styleTag) =>
         new Promise((resolve) => {
+          const clone = cloneNode(styleTag);
+
           // Load styles
-          styleTag.addEventListener('load', () => resolve(undefined), { once: true });
-          shadowRoot.append(styleTag);
+          clone.addEventListener('load', () => resolve(undefined), { once: true });
+          shadowRoot.append(clone);
 
           // Max 10s timeout
           window.setTimeout(() => resolve(undefined), 10000);

--- a/packages/inject/src/factory.ts
+++ b/packages/inject/src/factory.ts
@@ -76,7 +76,11 @@ const initComponent = async (componentTargetData: ComponentTargetData): Promise<
 
           // Normal component injection
           else {
-            target.append(component);
+            if (componentTargetData.replace) {
+              target.replaceWith(component);
+            } else {
+              target.append(component);
+            }
           }
         };
 

--- a/packages/inject/src/utils/types.ts
+++ b/packages/inject/src/utils/types.ts
@@ -1,5 +1,5 @@
 export type ComponentTargetData = {
-  target: HTMLElement;
+  target: Element;
   instance: string | null;
   source?: URL;
   proxiedSource?: URL;
@@ -7,6 +7,7 @@ export type ComponentTargetData = {
   autoRender: boolean;
   resetIx: boolean;
   positions: number[];
+  replace?: boolean;
 };
 
 export type ComponentData = ComponentTargetData & {


### PR DESCRIPTION
Support the `richtext` syntax from `v1` out of the box.
We scan for any RTB element that uses the syntax and automatically replace that element with the corresponding component.