### PR TITLE
feat: `removequery`

### DIFF
--- a/.changeset/public-moles-post.md
+++ b/.changeset/public-moles-post.md
@@ -1,0 +1,6 @@
+---
+'@finsweet/attributes': minor
+'@finsweet/attributes-utils': minor
+---
+
+feat: `removequery`

--- a/packages/attributes/package.json
+++ b/packages/attributes/package.json
@@ -56,6 +56,7 @@
     "@finsweet/attributes-queryparam": "workspace:*",
     "@finsweet/attributes-rangeslider": "workspace:*",
     "@finsweet/attributes-readtime": "workspace:*",
+    "@finsweet/attributes-removequery": "workspace:*",
     "@finsweet/attributes-scrolldisable": "workspace:*",
     "@finsweet/attributes-selectcustom": "workspace:*",
     "@finsweet/attributes-sliderdots": "workspace:*",

--- a/packages/attributes/src/load.ts
+++ b/packages/attributes/src/load.ts
@@ -82,6 +82,10 @@ export const loadAttribute = async (key: FinsweetAttributeKey) => {
       return import('@finsweet/attributes-readtime');
     }
 
+    case 'removequery': {
+      return import('@finsweet/attributes-removequery');
+    }
+
     case 'scrolldisable': {
       return import('@finsweet/attributes-scrolldisable');
     }

--- a/packages/removequery/README.md
+++ b/packages/removequery/README.md
@@ -1,0 +1,25 @@
+# `removequery` Attribute
+
+Remove the URL query parameters from the URL after the page loads.
+
+## Getting Started
+
+Please follow the documentation at [finsweet.com/attributes](https://www.finsweet.com/attributes) to learn how to use Attributes in your Webflow projects.
+
+## Accessing the API
+
+To learn how to access the API, please check the general [API Reference](../attributes/README.md#api-reference) documentation:
+
+```javascript
+window.FinsweetAttributes ||= [];
+window.FinsweetAttributes.push([
+  'removequery',
+  () => {
+    // Your code goes here.
+  },
+]);
+```
+
+## License
+
+[Apache 2.0](../../LICENSE.md)

--- a/packages/removequery/package.json
+++ b/packages/removequery/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@finsweet/attributes-removequery",
+  "version": "0.0.0",
+  "description": "Remove the URL query parameters from the URL after the page loads.",
+  "private": true,
+  "type": "module",
+  "types": "src/index.ts",
+  "scripts": {
+    "lint": "eslint ./src && prettier --check ./src",
+    "lint:fix": "eslint ./src --fix && prettier --write ./src",
+    "check": "tsc --noEmit"
+  },
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts"
+    }
+  },
+  "dependencies": {
+    "@finsweet/attributes-utils": "workspace:*"
+  }
+}

--- a/packages/removequery/src/index.ts
+++ b/packages/removequery/src/index.ts
@@ -1,0 +1,3 @@
+export { version } from '../package.json';
+export { init } from './init';
+export { ELEMENTS, SETTINGS } from './utils/constants';

--- a/packages/removequery/src/init.ts
+++ b/packages/removequery/src/init.ts
@@ -1,0 +1,18 @@
+import { type FinsweetAttributeInit, waitAttributeLoaded, waitWebflowReady } from '@finsweet/attributes-utils';
+
+/**
+ * Inits the attribute.
+ */
+export const init: FinsweetAttributeInit = async () => {
+  await waitWebflowReady();
+  await waitAttributeLoaded('list');
+  await waitAttributeLoaded('queryparam');
+
+  const url = new URL(window.location.href);
+
+  url.search = '';
+
+  window.history.replaceState({}, '', url);
+
+  return {};
+};

--- a/packages/removequery/src/utils/constants.ts
+++ b/packages/removequery/src/utils/constants.ts
@@ -1,0 +1,5 @@
+import { type AttributeElements, type AttributeSettings } from '@finsweet/attributes-utils';
+
+export const ELEMENTS = [] as const satisfies AttributeElements;
+
+export const SETTINGS = {} as const satisfies AttributeSettings;

--- a/packages/removequery/tsconfig.json
+++ b/packages/removequery/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.json"
+}

--- a/packages/utils/src/constants/attributes.ts
+++ b/packages/utils/src/constants/attributes.ts
@@ -52,4 +52,6 @@ export const TOC_ATTRIBUTE = 'toc';
 
 export const READ_TIME_ATTRIBUTE = 'readtime';
 
+export const REMOVE_QUERY_ATTRIBUTE = 'removequery';
+
 export const VIDEO_HLS_ATTRIBUTE = 'videohls';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,6 +114,9 @@ importers:
       '@finsweet/attributes-readtime':
         specifier: workspace:*
         version: link:../readtime
+      '@finsweet/attributes-removequery':
+        specifier: workspace:*
+        version: link:../removequery
       '@finsweet/attributes-scrolldisable':
         specifier: workspace:*
         version: link:../scrolldisable
@@ -314,6 +317,12 @@ importers:
         version: 1.1.0
 
   packages/readtime:
+    dependencies:
+      '@finsweet/attributes-utils':
+        specifier: workspace:*
+        version: link:../utils
+
+  packages/removequery:
     dependencies:
       '@finsweet/attributes-utils':
         specifier: workspace:*


### PR DESCRIPTION
New `removequery` Attribute. Does what the title says:
> Remove the URL query parameters from the URL after the page loads.