### PR TITLE
fix: linkedin share URL

### DIFF
--- a/.changeset/clean-icons-remain.md
+++ b/.changeset/clean-icons-remain.md
@@ -1,0 +1,5 @@
+---
+'@finsweet/attributes-socialshare': patch
+---
+
+fix: linkedin share URL

--- a/packages/socialshare/src/utils/constants.ts
+++ b/packages/socialshare/src/utils/constants.ts
@@ -89,6 +89,6 @@ export const SOCIAL_SHARE_PLATFORMS = {
   x: 'https://x.com/intent/post/',
   pinterest: 'https://www.pinterest.com/pin/create/trigger/',
   reddit: 'https://www.reddit.com/submit',
-  linkedin: 'https://www.linkedin.com//sharing/share-offsite',
+  linkedin: 'https://www.linkedin.com/sharing/share-offsite',
   telegram: 'https://t.me/share',
 } as const;


### PR DESCRIPTION
Closes #652 