### PR TITLE
feat: `fs-list-showtag`

### DIFF
--- a/.changeset/five-colts-allow.md
+++ b/.changeset/five-colts-allow.md
@@ -1,0 +1,5 @@
+---
+'@finsweet/attributes-list': minor
+---
+
+feat: `fs-list-showtag`

--- a/packages/list/src/filter/dynamic/conditions.ts
+++ b/packages/list/src/filter/dynamic/conditions.ts
@@ -604,6 +604,7 @@ export const initCondition = (list: List, element: HTMLElement, conditionGroup: 
     value,
     fuzzyThreshold,
     fieldMatch,
+    showTag: true,
     interacted: true,
   });
 

--- a/packages/list/src/filter/standard/conditions.ts
+++ b/packages/list/src/filter/standard/conditions.ts
@@ -7,7 +7,7 @@ import {
 } from '@finsweet/attributes-utils';
 
 import type { List } from '../../components/List';
-import { CUSTOM_VALUE_ATTRIBUTE, getAttribute, getSettingSelector } from '../../utils/selectors';
+import { CUSTOM_VALUE_ATTRIBUTE, getAttribute, getSettingSelector, hasAttributeValue } from '../../utils/selectors';
 import type { FiltersCondition, FiltersGroup } from '../types';
 
 /**
@@ -26,6 +26,7 @@ export const getConditionData = (formField: FormField, fieldKey: string, interac
   const filterMatch = getAttribute(formField, 'filtermatch', { filterInvalid: true });
   const fieldMatch = getAttribute(formField, 'fieldmatch', { filterInvalid: true });
   const fuzzyThreshold = getAttribute(formField, 'fuzzy');
+  const showTag = !hasAttributeValue(formField, 'showtag', 'false');
 
   const value = getFormFieldValue(formField, CUSTOM_VALUE_ATTRIBUTE);
 
@@ -40,6 +41,7 @@ export const getConditionData = (formField: FormField, fieldKey: string, interac
     fuzzyThreshold,
     interacted,
     customTagField,
+    showTag,
   };
 };
 

--- a/packages/list/src/filter/tags.ts
+++ b/packages/list/src/filter/tags.ts
@@ -117,6 +117,7 @@ export const initTags = (list: List, isDynamic: boolean) => {
 
             // Remove the tag if the value is empty
             const shouldRender =
+              condition.showTag &&
               !!condition.interacted &&
               !!condition.value &&
               (Array.isArray(condition.value) ? !!condition.value.length : true);

--- a/packages/list/src/filter/types.ts
+++ b/packages/list/src/filter/types.ts
@@ -12,7 +12,6 @@ export type FilterMatch = 'and' | 'or';
 export type FiltersCondition = {
   id: string;
   fieldKey: string;
-  customTagField?: string;
   op?: FilterOperator;
   type: FormFieldType;
   value: string | string[];
@@ -20,6 +19,8 @@ export type FiltersCondition = {
   fieldMatch?: FilterMatch;
   fuzzyThreshold?: number;
   interacted?: boolean;
+  customTagField?: string;
+  showTag: boolean;
 };
 
 export type FiltersGroup = {

--- a/packages/list/src/utils/constants.ts
+++ b/packages/list/src/utils/constants.ts
@@ -571,6 +571,11 @@ export const SETTINGS = {
   tagfield: { key: 'tagfield' },
 
   /**
+   * Defines if the tag for a specific filter should be displayed.
+   */
+  showtag: { key: 'showtag', values: ['false'] },
+
+  /**
    * If added to a tag, numeric and date numbers will be formatted when displaying them in the tags.
    * If "true" the format will default to the user’s locale.
    * A specific locale can be forced using IETF BCP 47 language tags like "en-US".


### PR DESCRIPTION
When adding `fs-list-showtag="false"` to any filter element, it won't display a tag.