### PR TITLE
fix: respect instances when multiple lists with pagination exist on the same page

### DIFF
--- a/.changeset/all-taxis-thank.md
+++ b/.changeset/all-taxis-thank.md
@@ -1,0 +1,5 @@
+---
+'@finsweet/attributes-list': patch
+---
+
+fix: respect instances when multiple lists with pagination exist on the same page

--- a/.changeset/evil-ears-bet.md
+++ b/.changeset/evil-ears-bet.md
@@ -1,0 +1,5 @@
+---
+'@finsweet/attributes-utils': patch
+---
+
+refactor: unnecessary expression

--- a/.changeset/gold-planes-unite.md
+++ b/.changeset/gold-planes-unite.md
@@ -1,0 +1,5 @@
+---
+'@finsweet/attributes-list': patch
+---
+
+fix: don't add aria-hidden to pagination buttons

--- a/packages/list/src/load/pagination.ts
+++ b/packages/list/src/load/pagination.ts
@@ -30,7 +30,6 @@ export const initPaginationMode = (list: List) => {
 
   // Init hook
   list.addHook('pagination', (items) => {
-    console.log('paginating...', { list, items });
     const $itemsPerPage = itemsPerPage.value;
 
     const start = (currentPage.value - 1) * $itemsPerPage;
@@ -348,8 +347,6 @@ const handlePaginationButtons = (list: List) => {
     const button = nextButton || previousButton;
 
     if (!button || getInstance(button) !== list.instance) return;
-
-    console.log({ isNextButton: nextButton, isPreviousButton: previousButton });
 
     e.preventDefault();
 

--- a/packages/list/src/load/pagination.ts
+++ b/packages/list/src/load/pagination.ts
@@ -350,11 +350,7 @@ const handlePaginationButtons = (list: List) => {
 
     e.preventDefault();
 
-    let targetPage: number | null | undefined;
-
-    if (nextButton) targetPage = list.currentPage.value + 1;
-    else targetPage = list.currentPage.value - 1;
-
+    const targetPage = nextButton ? list.currentPage.value + 1 : list.currentPage.value - 1;
     if (!targetPage) return;
     if (targetPage < 1) return;
     if (targetPage > list.totalPages.value) return;

--- a/packages/list/src/load/pagination.ts
+++ b/packages/list/src/load/pagination.ts
@@ -15,7 +15,7 @@ import debounce from 'just-debounce';
 import type { List } from '../components/List';
 import { BREAKPOINTS_INDEX } from '../utils/constants';
 import { getCMSElementSelector } from '../utils/dom';
-import { getAttribute, getElementSelector, queryElement } from '../utils/selectors';
+import { getAttribute, getElementSelector, getInstance, queryElement } from '../utils/selectors';
 import { loadPaginatedCMSItems } from './load';
 
 /**
@@ -30,6 +30,7 @@ export const initPaginationMode = (list: List) => {
 
   // Init hook
   list.addHook('pagination', (items) => {
+    console.log('paginating...', { list, items });
     const $itemsPerPage = itemsPerPage.value;
 
     const start = (currentPage.value - 1) * $itemsPerPage;
@@ -311,7 +312,6 @@ const handlePaginationButtons = (list: List) => {
     element.style.display = '';
     element.classList[shouldDisplay ? 'remove' : 'add'](disabledClass);
     element.setAttribute('aria-disabled', shouldDisplay ? 'false' : 'true');
-    element.setAttribute('aria-hidden', shouldDisplay ? 'false' : 'true');
     element.setAttribute('tabindex', shouldDisplay ? '0' : '-1');
   };
 
@@ -342,23 +342,25 @@ const handlePaginationButtons = (list: List) => {
 
     if (!isElement(target)) return;
 
-    const isNextButton = target.closest(getCMSElementSelector('pagination-next'));
-    const isPreviousButton = target.closest(getCMSElementSelector('pagination-previous'));
+    const nextButton = target.closest(getCMSElementSelector('pagination-next'));
+    const previousButton = target.closest(getCMSElementSelector('pagination-previous'));
 
-    if (!isNextButton && !isPreviousButton) return;
+    const button = nextButton || previousButton;
+
+    if (!button || getInstance(button) !== list.instance) return;
+
+    console.log({ isNextButton: nextButton, isPreviousButton: previousButton });
 
     e.preventDefault();
 
-    const { currentPage, totalPages } = list;
-
     let targetPage: number | null | undefined;
 
-    if (isNextButton) targetPage = currentPage.value + 1;
-    else targetPage = currentPage.value - 1;
+    if (nextButton) targetPage = list.currentPage.value + 1;
+    else targetPage = list.currentPage.value - 1;
 
     if (!targetPage) return;
     if (targetPage < 1) return;
-    if (targetPage > totalPages.value) return;
+    if (targetPage > list.totalPages.value) return;
 
     list.currentPage.value = targetPage;
   });

--- a/packages/utils/src/helpers/selectors.ts
+++ b/packages/utils/src/helpers/selectors.ts
@@ -76,7 +76,7 @@ export const generateSelectors = <
     }
 
     // If instance exists, select the specific element instance
-    const instanceSelector = `[${INSTANCE_ATTRIBUTE_NAME}="${instance}"]`;
+    const instanceSelector = getInstanceSelector(instance);
 
     return `${elementSelector}${instanceSelector}, ${instanceSelector} ${elementSelector}`;
   };


### PR DESCRIPTION
Click listeners on pagination buttons don't respect list instances at this moment.
I also included a couple fixes more:
- fix: don't add aria-hidden to pagination buttons
- refactor: unnecessary expression in `getElementSelector`