### PR TITLE
fix: use optional chaining for `window.CSS.registerProperty`

### DIFF
--- a/.changeset/fruity-weeks-walk.md
+++ b/.changeset/fruity-weeks-walk.md
@@ -1,0 +1,5 @@
+---
+'@finsweet/attributes-list': patch
+---
+
+fix: use optional chaining for `window.CSS.registerProperty`

--- a/packages/list/src/utils/constants.ts
+++ b/packages/list/src/utils/constants.ts
@@ -720,7 +720,7 @@ export const ALLOWED_DYNAMIC_FIELD_TYPES: Record<
 
 export const RENDER_INDEX_CSS_VARIABLE = `--fs-${LIST_ATTRIBUTE}-renderindex`;
 
-window.CSS.registerProperty({
+window.CSS?.registerProperty?.({
   name: RENDER_INDEX_CSS_VARIABLE,
   syntax: '<number>',
   inherits: false,


### PR DESCRIPTION
To support older versions of Firefox