### PR TITLE
feat: `fs-list-split`

### DIFF
--- a/.changeset/brown-worms-serve.md
+++ b/.changeset/brown-worms-serve.md
@@ -1,0 +1,5 @@
+---
+'@finsweet/attributes-list': minor
+---
+
+feat: `fs-list-split`

--- a/packages/list/src/filter/dynamic/conditions.ts
+++ b/packages/list/src/filter/dynamic/conditions.ts
@@ -6,6 +6,7 @@ import {
   type FormFieldType,
   isFormField,
   isHTMLSelectElement,
+  isString,
   setFormFieldValue,
   simulateEvent,
 } from '@finsweet/attributes-utils';
@@ -360,8 +361,18 @@ const initConditionValueField = (
 
     const activeFormField = allConditionValueFormFields.get(activeFormFieldType)!;
 
-    const value = getConditionValue(activeFormField);
     const fuzzyThreshold = getAttribute(activeFormField, 'fuzzy');
+    const rawSplitSeparator = getAttribute(activeFormField, 'split');
+    const splitSeparator = rawSplitSeparator === 'true' ? ' ' : rawSplitSeparator;
+
+    let value = getConditionValue(activeFormField);
+
+    if (isString(value) && splitSeparator) {
+      value = value
+        .split(splitSeparator)
+        .map((v) => v.trim())
+        .filter(Boolean);
+    }
 
     Object.assign(filtersCondition, {
       value,

--- a/packages/list/src/filter/dynamic/conditions.ts
+++ b/packages/list/src/filter/dynamic/conditions.ts
@@ -23,6 +23,7 @@ import {
   queryElement,
 } from '../../utils/selectors';
 import type { AllFieldsData, FilterOperator, FiltersCondition } from '../types';
+import { getSplitSeparator, splitValue } from '../utils';
 import { type ConditionGroup, getFiltersGroup } from './groups';
 import { getFilterMatchValue, parseOperatorValue } from './utils';
 
@@ -362,16 +363,12 @@ const initConditionValueField = (
     const activeFormField = allConditionValueFormFields.get(activeFormFieldType)!;
 
     const fuzzyThreshold = getAttribute(activeFormField, 'fuzzy');
-    const rawSplitSeparator = getAttribute(activeFormField, 'split');
-    const splitSeparator = rawSplitSeparator === 'true' ? ' ' : rawSplitSeparator;
+    const splitSeparator = getSplitSeparator(activeFormField);
 
     let value = getConditionValue(activeFormField);
 
     if (isString(value) && splitSeparator) {
-      value = value
-        .split(splitSeparator)
-        .map((v) => v.trim())
-        .filter(Boolean);
+      value = splitValue(value, splitSeparator);
     }
 
     Object.assign(filtersCondition, {

--- a/packages/list/src/filter/standard/conditions.ts
+++ b/packages/list/src/filter/standard/conditions.ts
@@ -3,6 +3,7 @@ import {
   type FormFieldType,
   getFormFieldValue,
   isFormField,
+  isString,
   setFormFieldValue,
 } from '@finsweet/attributes-utils';
 
@@ -27,8 +28,17 @@ export const getConditionData = (formField: FormField, fieldKey: string, interac
   const fieldMatch = getAttribute(formField, 'fieldmatch', { filterInvalid: true });
   const fuzzyThreshold = getAttribute(formField, 'fuzzy');
   const showTag = !hasAttributeValue(formField, 'showtag', 'false');
+  const rawSplitSeparator = getAttribute(formField, 'split');
+  const splitSeparator = rawSplitSeparator === 'true' ? ' ' : rawSplitSeparator;
 
-  const value = getFormFieldValue(formField, CUSTOM_VALUE_ATTRIBUTE);
+  let value = getFormFieldValue(formField, CUSTOM_VALUE_ATTRIBUTE);
+
+  if (isString(value) && splitSeparator) {
+    value = value
+      .split(splitSeparator)
+      .map((v) => v.trim())
+      .filter(Boolean);
+  }
 
   return {
     id,

--- a/packages/list/src/filter/standard/conditions.ts
+++ b/packages/list/src/filter/standard/conditions.ts
@@ -10,6 +10,7 @@ import {
 import type { List } from '../../components/List';
 import { CUSTOM_VALUE_ATTRIBUTE, getAttribute, getSettingSelector, hasAttributeValue } from '../../utils/selectors';
 import type { FiltersCondition, FiltersGroup } from '../types';
+import { getSplitSeparator, splitValue } from '../utils';
 
 /**
  * @returns The value of a given form field.
@@ -28,16 +29,12 @@ export const getConditionData = (formField: FormField, fieldKey: string, interac
   const fieldMatch = getAttribute(formField, 'fieldmatch', { filterInvalid: true });
   const fuzzyThreshold = getAttribute(formField, 'fuzzy');
   const showTag = !hasAttributeValue(formField, 'showtag', 'false');
-  const rawSplitSeparator = getAttribute(formField, 'split');
-  const splitSeparator = rawSplitSeparator === 'true' ? ' ' : rawSplitSeparator;
+  const splitSeparator = getSplitSeparator(formField);
 
   let value = getFormFieldValue(formField, CUSTOM_VALUE_ATTRIBUTE);
 
   if (isString(value) && splitSeparator) {
-    value = value
-      .split(splitSeparator)
-      .map((v) => v.trim())
-      .filter(Boolean);
+    value = splitValue(value, splitSeparator);
   }
 
   return {

--- a/packages/list/src/filter/utils.ts
+++ b/packages/list/src/filter/utils.ts
@@ -9,6 +9,7 @@ import {
 import * as fuzzysort from 'fuzzysort';
 
 import type { ListItemField } from '../components';
+import { getAttribute } from '../utils/selectors';
 import type { FieldValue } from './types';
 
 /**
@@ -124,3 +125,25 @@ export const numericCompare = (
 
   return false;
 };
+
+/**
+ * @returns The split separator for the element.
+ * @param element
+ */
+export const getSplitSeparator = (element: Element) => {
+  const rawSplitSeparator = getAttribute(element, 'split');
+
+  const splitSeparator = rawSplitSeparator === 'true' ? ' ' : rawSplitSeparator;
+  return splitSeparator;
+};
+
+/**
+ * Splits the value by the given separator and trims each part.
+ * @param value
+ * @param separator
+ */
+export const splitValue = (value: string, separator: string) =>
+  value
+    .split(separator)
+    .map((v) => v.trim())
+    .filter(Boolean);

--- a/packages/list/src/utils/constants.ts
+++ b/packages/list/src/utils/constants.ts
@@ -551,6 +551,12 @@ export const SETTINGS = {
   value: { key: 'value' },
 
   /**
+   * Defines a split separator for a filter value.
+   * If set to `true`, it will use a space as a separator.
+   */
+  split: { key: 'split' },
+
+  /**
    * Defines a list instance where the list should be combined with.
    */
   combine: { key: 'combine' },


### PR DESCRIPTION
Introduces the `fs-list-split` attribute for filter fields, allowing string values to be split into arrays using a specified separator (defaulting to space if set to 'true').