### PR TITLE
fix: filter the list on page load if there are default values

### DIFF
--- a/.changeset/eager-places-burn.md
+++ b/.changeset/eager-places-burn.md
@@ -1,0 +1,5 @@
+---
+'@finsweet/attributes-list': patch
+---
+
+fix: filter the list on page load if there are default values

--- a/packages/list/src/filter/index.ts
+++ b/packages/list/src/filter/index.ts
@@ -70,7 +70,7 @@ export const initListFiltering = (list: List, forms: HTMLFormElement[]) => {
         setListFiltersQuery(list);
       }
     }, 0),
-    { deep: true }
+    { deep: true, immediate: true }
   );
 
   // Read query params


### PR DESCRIPTION
Lists that have default values, like a radio with a `checked="checked"` attribute are currently not being filtered on page load.