### PR TITLE
fix: initialize nesting inside combined items

### DIFF
--- a/.changeset/legal-doors-tap.md
+++ b/.changeset/legal-doors-tap.md
@@ -1,0 +1,5 @@
+---
+'@finsweet/attributes-list': patch
+---
+
+fix: initialize nesting inside combined items

--- a/packages/list/src/factory.ts
+++ b/packages/list/src/factory.ts
@@ -46,9 +46,6 @@ export const createListInstance = (referenceElement: HTMLElement): List | undefi
 export const initList = (list: List) => {
   const { instance } = list;
 
-  const items = list.items.value;
-  const firstItemElement = items[0]?.element;
-
   const cleanups = new Set<(() => void) | undefined>();
 
   // Filter
@@ -80,11 +77,8 @@ export const initList = (list: List) => {
   }
 
   // Nest
-  const nest = !!firstItemElement && !!queryElement('nest-target', { scope: firstItemElement });
-  if (nest) {
-    const cleanup = initListNest(list);
-    cleanups.add(cleanup);
-  }
+  const nestCleanup = initListNest(list);
+  cleanups.add(nestCleanup);
 
   // Static Items
   const listSelector = getElementSelector('list', { instance });


### PR DESCRIPTION
Sometimes nesting is not initialized when items come from a combined list.
We don't need the current check, if there is no nesting targets the nest initialization already bails out.