### PR TITLE
feat: prefer instances over pagination query for filters & sorting params

### DIFF
--- a/.changeset/great-places-smell.md
+++ b/.changeset/great-places-smell.md
@@ -1,0 +1,5 @@
+---
+'@finsweet/attributes-list': minor
+---
+
+feat: prefer instances over pagination query for filters & sorting params

--- a/packages/list/src/filter/standard/query.ts
+++ b/packages/list/src/filter/standard/query.ts
@@ -81,7 +81,7 @@ export const setListFiltersQuery = async (list: List) => {
   for (const [key] of existingParams) {
     if (!key.match(regex)) continue;
 
-    await list.setSearchParam(key, null, usePrefix);
+    await list.setSearchParam(key, null, { usePrefix });
   }
 
   const multipleGroups = list.filters.value.groups.length > 1;
@@ -105,7 +105,7 @@ export const setListFiltersQuery = async (list: List) => {
         valueToSet = value;
       }
 
-      list.setSearchParam(key, valueToSet, usePrefix);
+      list.setSearchParam(key, valueToSet, { usePrefix });
     });
   });
 };

--- a/packages/list/src/load/pagination.ts
+++ b/packages/list/src/load/pagination.ts
@@ -50,7 +50,7 @@ export const initPaginationMode = async (list: List) => {
       }
 
       if (list.showQuery) {
-        list.setSearchParam('page', currentPage.value.toString());
+        list.setSearchParam('page', currentPage.value.toString(), { useSearchParamsPrefix: true });
       }
     },
     {}

--- a/packages/list/src/sort/query.ts
+++ b/packages/list/src/sort/query.ts
@@ -51,7 +51,7 @@ export const setListSortingQuery = async (list: List) => {
   for (const [key] of existingParams) {
     if (!key.match(regex)) continue;
 
-    await list.setSearchParam(key, null, usePrefix);
+    await list.setSearchParam(key, null, { usePrefix });
   }
 
   const { fieldKey, direction } = list.sorting.value;
@@ -59,5 +59,5 @@ export const setListSortingQuery = async (list: List) => {
 
   const key = `sort_${fieldKey}`;
 
-  list.setSearchParam(key, direction, usePrefix);
+  list.setSearchParam(key, direction, { usePrefix });
 };


### PR DESCRIPTION
I've kept backwards compatibility by reading the pagination query as well if the instance prefix doesn't return any value.