### PR TITLE
fix: pagination buttons retrieval when using non-CMS lists

### DIFF
--- a/.changeset/mean-lights-stare.md
+++ b/.changeset/mean-lights-stare.md
@@ -1,0 +1,5 @@
+---
+'@finsweet/attributes-list': patch
+---
+
+fix: pagination buttons retrieval when using non-CMS lists

--- a/packages/list/src/components/List.ts
+++ b/packages/list/src/components/List.ts
@@ -744,6 +744,8 @@ export class List {
         const $currentPage = currentPage.value;
         if (!$currentPage || $currentPage === 1) return;
 
+        if (!paginationSearchParam) return;
+
         const page = await fetchPage(`${origin}${pathname}?${paginationSearchParam}=${$currentPage - 1}`);
         if (!page) return;
 
@@ -766,6 +768,7 @@ export class List {
       // Pagination previous & Empty state
       (async () => {
         if (paginationPreviousCMSElement.value && emptyElement.value) return;
+        if (!paginationSearchParam) return;
 
         const page = await fetchPage(`${origin}${pathname}?${paginationSearchParam}=9999`);
         if (!page) return;


### PR DESCRIPTION
Sometimes it causes buttons to be duplicated.