### PR TITLE
feat: close mobile keyboards after submitting

### DIFF
--- a/.changeset/clear-goats-invent.md
+++ b/.changeset/clear-goats-invent.md
@@ -1,0 +1,5 @@
+---
+'@finsweet/attributes-list': minor
+---
+
+feat: close mobile keyboards after submitting

--- a/packages/list/src/filter/elements.ts
+++ b/packages/list/src/filter/elements.ts
@@ -4,6 +4,7 @@ import {
   getFormFieldWrapper,
   getRadioGroupInputs,
   isFormField,
+  isHTMLInputElement,
 } from '@finsweet/attributes-utils';
 import { effect } from '@vue/reactivity';
 
@@ -38,9 +39,21 @@ export const handleFiltersForm = (form: HTMLFormElement) => {
   const allowSubmit = hasAttributeValue(form, 'allowsubmit', 'true');
 
   const submitCleanup = addListener(form, 'submit', (e) => {
-    if (!allowSubmit) {
-      e.preventDefault();
-      e.stopPropagation();
+    if (allowSubmit) return;
+
+    e.preventDefault();
+    e.stopPropagation();
+
+    // Blur active input on mobile devices to close virtual keyboard
+    const { activeElement } = document;
+
+    const isTouch = matchMedia('(pointer: coarse)').matches;
+    const isMobileUA = /Mobi|Android|iPhone|iPad/i.test(navigator.userAgent);
+
+    const isVirtualKeyboardLikely = isTouch || isMobileUA;
+
+    if (isVirtualKeyboardLikely && isHTMLInputElement(activeElement)) {
+      activeElement.blur();
     }
   });
 


### PR DESCRIPTION
When submitting a filters form on a mobile device, the keyboard stays open which can be annoying.
This update checks if the user is on a mobile device and blurs the currently focused input to dismiss the keyboard.