### PR TITLE
feat: `fs-list-tagvalues="separate"`

### DIFF
--- a/.changeset/pretty-humans-brush.md
+++ b/.changeset/pretty-humans-brush.md
@@ -1,0 +1,5 @@
+---
+'@finsweet/attributes-list': minor
+---
+
+feat: `fs-list-tagvalues="separate"`

--- a/packages/list/src/filter/standard/conditions.ts
+++ b/packages/list/src/filter/standard/conditions.ts
@@ -30,7 +30,8 @@ export const getConditionData = (formField: FormField, fieldKey: string, interac
   const op = getConditionOperator(formField);
   const id = `${fieldKey}_${op}`;
 
-  const customTagField = getAttribute(formField, 'tagfield');
+  const tagFieldDisplay = getAttribute(formField, 'tagfield');
+  const tagValuesDisplay = getAttribute(formField, 'tagvalues', { filterInvalid: true });
   const filterMatch = getAttribute(formField, 'filtermatch', { filterInvalid: true });
   const fieldMatch = getAttribute(formField, 'fieldmatch', { filterInvalid: true });
   const fuzzyThreshold = getAttribute(formField, 'fuzzy');
@@ -53,7 +54,8 @@ export const getConditionData = (formField: FormField, fieldKey: string, interac
     fieldMatch,
     fuzzyThreshold,
     interacted,
-    customTagField,
+    tagFieldDisplay,
+    tagValuesDisplay,
     showTag,
   };
 };

--- a/packages/list/src/filter/types.ts
+++ b/packages/list/src/filter/types.ts
@@ -4,8 +4,8 @@ import type { ListItem, ListItemField } from '../components';
 import type { SETTINGS } from '../utils/constants';
 
 // General
-type FilterOperatorValues = (typeof SETTINGS)['operator']['values'];
-export type FilterOperator = FilterOperatorValues[number];
+export type FilterOperator = (typeof SETTINGS)['operator']['values'][number];
+export type FilterTagValuesDisplay = (typeof SETTINGS)['tagvalues']['values'][number];
 
 export type FilterMatch = 'and' | 'or';
 
@@ -19,7 +19,8 @@ export type FiltersCondition = {
   fieldMatch?: FilterMatch;
   fuzzyThreshold?: number;
   interacted?: boolean;
-  customTagField?: string;
+  tagFieldDisplay?: string;
+  tagValuesDisplay: FilterTagValuesDisplay;
   showTag: boolean;
 };
 

--- a/packages/list/src/utils/constants.ts
+++ b/packages/list/src/utils/constants.ts
@@ -577,6 +577,11 @@ export const SETTINGS = {
   tagfield: { key: 'tagfield' },
 
   /**
+   * Defines how to render tag values.
+   */
+  tagvalues: { key: 'tagvalues', values: ['combined', 'separate'], defaultValue: 'combined' },
+
+  /**
    * Defines if the tag for a specific filter should be displayed.
    */
   showtag: { key: 'showtag', values: ['false'] },


### PR DESCRIPTION
This new attribute will split the rendering of multi-value conditions into separate tags.
The default behavior of combining the values into a single tag remains the same to avoid breaking changes.