### PR TITLE
fix: nested list item fields detection

### DIFF
--- a/.changeset/short-numbers-itch.md
+++ b/.changeset/short-numbers-itch.md
@@ -1,0 +1,5 @@
+---
+'@finsweet/attributes-list': patch
+---
+
+fix: nested list item fields detection

--- a/packages/list/src/components/ListItem.ts
+++ b/packages/list/src/components/ListItem.ts
@@ -162,7 +162,7 @@ export class ListItem {
 
       const listSelector = getCMSElementSelector('list');
       const parentList = element.closest(listSelector);
-      const isInsideNestedList = this.list.listElement && parentList && parentList !== this.list.listElement;
+      const isInsideNestedList = this.element.contains(parentList);
 
       if (isInsideNestedList) {
         this.fields[fieldKey] ||= { type, rawValue: [], value: [] };


### PR DESCRIPTION
In some cases the fields were being mistakenly detected as nested, causing filtering issues.